### PR TITLE
Update helm-release.yml

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
         with:
-          skip_existing: true
+          skip_existing: false
           packages_with_index: true
           charts_dir: charts/
         env:


### PR DESCRIPTION
Updating a setting that will package/ upload the release on every run, which should hopefully cause the package to re-upload to the `gh-pages` branch correctly.