### PR TITLE
feat: add feature to configure ollama service labels via values

### DIFF
--- a/charts/open-webui/templates/ollama-service.yaml
+++ b/charts/open-webui/templates/ollama-service.yaml
@@ -5,6 +5,9 @@ metadata:
   name: {{ include "ollama.name" . }}
   labels:
     {{- include "ollama.labels" . | nindent 4 }}
+    {{- with .Values.ollama.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ollama.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -29,6 +29,7 @@ ollama:
   service:
     type: ClusterIP
     annotations: {}
+    labels: {}
     port: 80
     containerPort: 11434
   gpu:
@@ -72,4 +73,4 @@ webui:
     containerPort: 8080
     nodePort: ""
     labels: {}
-    loadBalancerClass: "" 
+    loadBalancerClass: ""


### PR DESCRIPTION
This commit adds the ability to configure labels for the ollama service in the values.yaml file. Users can now specify custom labels for the ollama service, providing greater flexibility in managing its configuration.