### PR TITLE
Update index.yaml

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -85,26 +85,4 @@ entries:
     urls:
     - open-webui-1.0.1.tgz
     version: 1.0.1
-  - annotations:
-      licenses: MIT
-    apiVersion: v2
-    appVersion: latest
-    created: "2024-05-07T01:38:29.223377794Z"
-    description: "Open WebUI: A User-Friendly Web Interface for Chat Interactions
-      \U0001F44B"
-    digest: 393634e08621bab8fcf3284d58a048bbf58dbf1bfa369e966edd263a978992e4
-    home: https://www.openwebui.com/
-    icon: https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png
-    keywords:
-    - llm
-    - chat
-    - web-ui
-    name: open-webui
-    sources:
-    - https://github.com/open-webui/open-webui/tree/main/kubernetes/helm
-    - https://hub.docker.com/r/ollama/ollama
-    - https://github.com/open-webui/open-webui/pkgs/container/open-webui
-    urls:
-    - open-webui-1.0.0.tgz
-    version: 1.0.0
 generated: "2024-05-09T16:33:11.663230582Z"


### PR DESCRIPTION
I'm working on getting the Helm Charts added to Artifact Hub so anyone searching for the chart there will be able to find it. I added the repo, but am hitting this error: `error preparing package: error loading chart (https://helm.openwebui.com/open-webui-1.0.0.tgz): not found (package: open-webui version: 1.0.0)`

I believe this is because that version is still called out in `index.yaml`, but is not present in the `gh-pages` branch anymore. I'm hoping that removing it from the index file will allow Artifact Hub to pick up the valid versions of the chart correctly.