### PR TITLE
fix: use StatefulSet instead of Deployment if persistence is enabled

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 3.0.1
-appVersion: "0.2.5"
+version: 3.0.2
+appVersion: "v0.3.4"
 
 home: https://www.openwebui.com/
 icon: https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -1,5 +1,9 @@
 apiVersion: apps/v1
+{{- if .Values.persistence.enabled }}
+kind: StatefulSet
+{{- else }}
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ include "open-webui.name" . }}
   labels:


### PR DESCRIPTION
This will help with deployment on multi nodes kubernetes cluster with the persistence enabled. That should fix issue #34.

I have tested that the `helm template` command works properly with and without the option:
```shell
helm template --set ollama.enabled=false --set pipelines.enabled=false --set persistence.enabled=false ./charts/open-webui
```

```shell
helm template --set ollama.enabled=false --set pipelines.enabled=false --set persistence.enabled=true ./charts/open-webui
```

I have also deployed the chart on a local minikube to confirm that the open webui container starts properly, and that switching from `persistence` enabled to disabled works.