### PR TITLE
feat: Allow optional clusterIP and loadBalancerIP fields on the openwebui service template

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 3.0.2
+version: 3.0.3
 appVersion: "v0.3.4"
 
 home: https://www.openwebui.com/

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![AppVersion: 0.2.2](https://img.shields.io/badge/AppVersion-0.2.2-informational?style=flat-square)
+![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square) ![AppVersion: v0.3.4](https://img.shields.io/badge/AppVersion-v0.3.4-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 

--- a/charts/open-webui/templates/service.yaml
+++ b/charts/open-webui/templates/service.yaml
@@ -26,4 +26,10 @@ spec:
   {{- if .Values.service.loadBalancerClass }}
   loadBalancerClass: {{ .Values.service.loadBalancerClass | quote }}
   {{- end }}
+  {{- if and (eq .Values.service.type "ClusterIP") (.Values.service.clusterIP) }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if and (eq .Values.service.type "loadBalancer") (.Values.service.loadBalancerIP) }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
   


### PR DESCRIPTION
### Enhancements

Adds two optional fields to the openwebui `service.yaml` template file:
- `clusterIP`: Only valid if service `type: ClusterIP` and defines a static IP address for the service
- `loadBalancerIP`: Only valid if service `type: LoadBalancer` and defines a static IP address for the service