### PR TITLE
fix: set serviceName in StatefulSet spec

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 3.0.4
-appVersion: "v0.3.4"
+version: 3.0.5
+appVersion: "v0.3.5"
 
 home: https://www.openwebui.com/
 icon: https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -14,6 +14,9 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.persistence.enabled }}
+  serviceName: {{ include "open-webui.name" . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "open-webui.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Misconfiguration fix from last PR: https://github.com/open-webui/helm-charts/pull/36#issuecomment-2184996280

This adds `serviceName` configuration in `spec` part of `StatefulSet`, as explained in the documentation: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id