### PR TITLE
Fix condition case on `loadBalancerIP`

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 3.1.7
+version: 3.1.8
 appVersion: "0.3.13"
 
 home: https://www.openwebui.com/

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 3.1.6](https://img.shields.io/badge/Version-3.1.6-informational?style=flat-square) ![AppVersion: 0.3.13](https://img.shields.io/badge/AppVersion-0.3.13-informational?style=flat-square)
+![Version: 3.1.8](https://img.shields.io/badge/Version-3.1.8-informational?style=flat-square) ![AppVersion: 0.3.13](https://img.shields.io/badge/AppVersion-0.3.13-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 

--- a/charts/open-webui/templates/service.yaml
+++ b/charts/open-webui/templates/service.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if and (eq .Values.service.type "ClusterIP") (.Values.service.clusterIP) }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
-  {{- if and (eq .Values.service.type "loadBalancer") (.Values.service.loadBalancerIP) }}
+ r{{- if and (eq .Values.service.type "LoadBalancer") (.Values.service.loadBalancerIP) }}
   loadBalancerIP: {{ .Values.service.loadBalancerIP }}
   {{- end }}
   


### PR DESCRIPTION
Based on Kubernetes service type [doc](https://github.com/open-webui/helm-charts/commit/d7a271013f863e878672160a8c240d12209f5618), the type of `LoadBalancer` is case sensitive.

Should be `LoadBalancer` instead of `loadBalancer`, thanks.