### PR TITLE
FIX: ollama url and env vars when ollama.enabled=False

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 3.1.18
+version: 3.1.19
 appVersion: "0.3.23"
 
 home: https://www.openwebui.com/

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
 version: 3.1.19
-appVersion: "0.3.23"
+appVersion: "0.3.24"
 
 home: https://www.openwebui.com/
 icon: https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 3.1.9](https://img.shields.io/badge/Version-3.1.8-informational?style=flat-square) ![AppVersion: 0.3.13](https://img.shields.io/badge/AppVersion-0.3.13-informational?style=flat-square)
+![Version: 3.1.19](https://img.shields.io/badge/Version-3.1.19-informational?style=flat-square) ![AppVersion: 0.3.13](https://img.shields.io/badge/AppVersion-0.3.13-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -73,8 +73,13 @@ spec:
         - name: data
           mountPath: /app/backend/data
         env:
+        {{ if .Values.ollama.enabled }}
         - name: OLLAMA_BASE_URLS
           value: {{ include "ollamaBaseUrls" . | quote }}
+        {{ else }}
+        - name: ENABLE_OLLAMA_API
+          value: "False"
+        {{- end }}
         {{ if .Values.pipelines.enabled }}
         - name: OPENAI_API_BASE_URL
           value: {{ include "pipelines.serviceEndpoint" . }}


### PR DESCRIPTION
- TL;DR:
 Fix showing Ollama URL in UI 

- Problem:
When ollama.enabled=False, OpenWebUI still showing empty ollama URL.

- Solution proposed in this PR:
For fix ollama in OpenWebUI need to set  ENABLE_OLLAMA_API to false and check make OLLAMA_BASE_URLS optional.

Checks:
- [x] Fork the repository
- [x] Make your changes
- [x] Test your changes
- [x] Kubernetes cluster (whether local or remote).
- [x] Run helm-docs
- [x] Commit your changes
- [x] Push your changes
- [x] Create a Pull Request
- [x] Bump chart version
