### PR TITLE
Support subPath for persistent volumes

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 3.4.3
+version: 3.5.0
 appVersion: "0.3.35"
 
 home: https://www.openwebui.com/

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 3.4.0](https://img.shields.io/badge/Version-3.4.0-informational?style=flat-square) ![AppVersion: 0.3.32](https://img.shields.io/badge/AppVersion-0.3.32-informational?style=flat-square)
+![Version: 3.5.0](https://img.shields.io/badge/Version-3.5.0-informational?style=flat-square) ![AppVersion: 0.3.35](https://img.shields.io/badge/AppVersion-0.3.35-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -66,6 +66,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | persistence.selector | object | `{}` |  |
 | persistence.size | string | `"2Gi"` |  |
 | persistence.storageClass | string | `""` |  |
+| persistence.subPath | string | `""` | Subdirectory of Open WebUI PVC to mount. Useful if root directory is not empty. |
 | pipelines.enabled | bool | `true` | Automatically install Pipelines chart to extend Open WebUI functionality using Pipelines: https://github.com/open-webui/pipelines |
 | pipelines.extraEnvVars | list | `[]` | This section can be used to pass required environment variables to your pipelines (e.g. Langfuse hostname) |
 | podAnnotations | object | `{}` |  |

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -47,6 +47,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /tmp/app-data
+          {{- if .Values.persistence.subPath }}
+          subPath: {{ .Values.persistence.subPath }}
+          {{- end }}
         {{- with .Values.volumeMounts.initContainer }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -75,6 +78,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /app/backend/data
+          {{- if .Values.persistence.subPath }}
+          subPath: {{ .Values.persistence.subPath }}
+          {{- end }}
         {{- with .Values.volumeMounts.container }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -60,6 +60,8 @@ persistence:
   size: 2Gi
   # -- Use existingClaim if you want to re-use an existing Open WebUI PVC instead of creating a new one
   existingClaim: ""
+  # -- Subdirectory of Open WebUI PVC to mount. Useful if root directory is not empty.
+  subPath: ""
   # -- If using multiple replicas, you must update accessModes to ReadWriteMany
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
This PRs adds a new parameter `subPath` to `values.yaml` which allows to use a sub folder within an existing volume claim. This is useful when one PVC is used for more applications.

Fixes #99.