### PR TITLE
feat: Add DuckDuckGo as the default search engine

### DIFF
--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -100,6 +100,11 @@ openaiBaseApiUrl: ""
 
 # -- Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/
 extraEnvVars:
+  # -- RAG Web Search configuration. Use DuckDuckGo as the default search engine
+  - name: "ENABLE_RAG_WEB_SEARCH"
+    value: "True"
+  - name: "RAG_WEB_SEARCH_ENGINE"
+    value: "duckduckgo"
   # -- Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines
   - name: OPENAI_API_KEY
     value: "0p3n-w3bu!"


### PR DESCRIPTION
User need WebSearch configuration after install. 
How about having DuckDuckGo configuration as default Web Search integration?
Other search engine need api key, then I choose DuckDuckGo in default.
 
