### PR TITLE
feat: allow additionalHosts for ingress

### DIFF
--- a/charts/open-webui/templates/ingress.yaml
+++ b/charts/open-webui/templates/ingress.yaml
@@ -17,6 +17,9 @@ spec:
   tls:
     - hosts:
       - {{ .Values.ingress.host | quote }}
+      {{- range .Values.ingress.additionalHosts }}
+      - {{ . | quote }}
+      {{- end }}
       secretName: {{ default (printf "%s-tls" .Release.Name) .Values.ingress.existingSecret }}
   {{- end }}
   rules:
@@ -30,4 +33,16 @@ spec:
             name: {{ include "open-webui.name" . }}
             port:
               name: http
+  {{- range .Values.ingress.additionalHosts }}
+  - host: {{ . | quote }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "open-webui.name" $ }}
+            port:
+              name: http
+  {{- end }}
 {{- end }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -57,6 +57,7 @@ ingress:
   # nginx.ingress.kubernetes.io/rewrite-target: /
   annotations: {}
   host: ""
+  additionalHosts: []
   tls: false
   existingSecret: ""
 persistence:


### PR DESCRIPTION
This allows others to provide multiple ingress hosts. That's nice for CNAMEs and similar approaches.

This change is not a breaking change and not setting the `additionalHosts` field will have no effect.

Here is an example output:

```yaml
ingress:
  enabled: true
  class: ""
  # -- Use appropriate annotations for your Ingress controller, e.g., for NGINX:
  # nginx.ingress.kubernetes.io/rewrite-target: /
  annotations: {}
  host: "chat.k8s.example.com"
  additionalHosts:
    - "gpt.example.com"
    - "chat.example.com"
  tls: true
  existingSecret: ""
```

```yaml
# Source: open-webui/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: open-webui
  labels:
    helm.sh/chart: open-webui-4.0.0
    app.kubernetes.io/version: "0.4.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/instance: test
    app.kubernetes.io/component: open-webui
spec:
  tls:
    - hosts:
      - "chat.k8s.example.com"
      - "gpt.example.com"
      - "chat.example.com"
      secretName: test-tls
  rules:
  - host: chat.k8s.example.com
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: open-webui
            port:
              name: http
  - host: "gpt.example.com"
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: open-webui
            port:
              name: http
  - host: "chat.example.com"
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: open-webui
            port:
              name: http
```