### PR TITLE
Fix broken ServiceAccount & introduce automated testing via CI

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm-test-open-webui.yml
+++ b/.github/workflows/helm-test-open-webui.yml
@@ -1,0 +1,52 @@
+name: Check Open WebUI Helm Charts (open-webui)
+
+on:
+  pull_request:
+    paths:
+      - "charts/open-webui/**"
+  push:
+    paths:
+      - "charts/open-webui/**"
+
+jobs:
+  lint-chart:
+    name: Lint Helm Chart
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint open-webui Helm Chart
+        run: |
+          helm lint ./charts/open-webui
+
+  test-deploy:
+    name: Test Chart Deployment
+    runs-on: ubuntu-latest
+    needs: lint-chart
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up KinD Cluster
+        uses: helm/kind-action@v1
+
+      - name: Template open-webui Helm Chart
+        run: |
+          helm template open-webui ./charts/open-webui \
+            --namespace test-namespace --create-namespace > open-webui.yaml
+
+      - name: Verify open-webui
+        run: |
+          kubectl apply -f open-webui.yaml

--- a/.github/workflows/helm-test-pipelines.yml
+++ b/.github/workflows/helm-test-pipelines.yml
@@ -1,0 +1,53 @@
+name: Check Open WebUI Helm Charts (pipelines)
+
+on:
+  pull_request:
+    paths:
+      - "charts/pipelines/**"
+  push:
+    paths:
+      - "charts/pipelines/**"
+
+jobs:
+  lint-chart:
+    name: Lint Helm Chart
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+      
+      - name: Lint pipelines Helm Chart
+        run: |
+          helm lint ./charts/pipelines
+
+  test-deploy:
+    name: Test Chart Deployment
+    runs-on: ubuntu-latest
+    needs: lint-chart
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up KinD Cluster
+        uses: helm/kind-action@v1
+
+      - name: Template open-webui Helm Chart
+        run: |
+          helm template pipelines ./charts/pipelines \
+            --namespace test-namespace --create-namespace > pipelines.yaml
+
+      - name: Verify pipelines
+        run: |
+          kubectl apply -f pipelines.yaml
+

--- a/charts/open-webui/templates/service-account.yaml
+++ b/charts/open-webui/templates/service-account.yaml
@@ -3,12 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name | default (include "open-webui.name" .) }}
-  automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
   labels:
     {{- include "open-webui.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 {{- end }}


### PR DESCRIPTION
This introduces automated CI checks so checking PRs becomes easier on the maintainers.

It does a helm linting check & tries to `kubectl apply` the created objects. If the kubernetes API returns a non-zero exit code, the pipeline will break and we know there is some issue with the provided templates (which then can be seen in the CI logs).

Other than that, I also fixed the broken ServiceAccount as `automountServiceAccountToken` is not part of `metadata`.