### PR TITLE
fix resources for copy-app-data init container

### DIFF
--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -41,11 +41,11 @@ spec:
         {{- end }}
         command: ['sh', '-c', 'cp -R -n /app/backend/data/* /tmp/app-data/']
         {{- with .Values.containerSecurityContext }}
-        {{- with .Values.copyAppData.resources }}
-        resources: {{- toYaml . | nindent 10 }}
-        {{- end }}
         securityContext:
           {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.copyAppData.resources }}
+        resources: {{- toYaml . | nindent 10 }}
         {{- end }}
         volumeMounts:
         - name: data

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -56,6 +56,10 @@ imagePullSecrets: []
 # - name: myRegistryKeySecretName
 
 resources: {}
+
+copyAppData:
+  resources: {}
+
 ingress:
   enabled: false
   class: ""


### PR DESCRIPTION
Upgrading charts fail w/ `Error: UPGRADE FAILED: template: open-webui/templates/workload-manager.yaml:47:24: executing open-webui/templates/workload-manager.yaml at <.Values.copyAppData.resources>: nil pointer evaluating interface {}.resources`