### PR TITLE
Fix Pipelines persistance

### DIFF
--- a/charts/pipelines/templates/deployment.yaml
+++ b/charts/pipelines/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         {{- end }}
         volumeMounts:
         - name: data
-          mountPath: /app/backend/data
+          mountPath: /app/pipelines
         env:
         {{- if .Values.extraEnvVars }}
           {{- toYaml .Values.extraEnvVars | nindent 8 }}


### PR DESCRIPTION
I might not fully understand, but currently the pipelines are not persisted between restarts because they are stored in `/app/piplines` which is not the current persistent volume. That one is `/app/backend/data`.

`/app/backend/data` is mentioned in [the Openweb-ui readme](https://github.com/open-webui/open-webui/blob/0a26c41c7b58300f37348ba580a4f0d682ca5fbd/README.md#L90) but I see no mention of it in the pipelines repo.