### PR TITLE
Enable service accounts for pipelines chart

### DIFF
--- a/charts/pipelines/templates/deployment.yaml
+++ b/charts/pipelines/templates/deployment.yaml
@@ -27,7 +27,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       enableServiceLinks: false
-      automountServiceAccountToken: false
+      automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken | default false }}
+      {{- if .Values.serviceAccount.enable }}
+      serviceAccountName: {{ .Values.serviceAccount.name | default (include "pipelines.name" .) }}
+      {{- end }}
+
       containers:
       - name: {{ .Chart.Name }}
         {{- with .Values.image }}

--- a/charts/pipelines/templates/service-account.yaml
+++ b/charts/pipelines/templates/service-account.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.enable }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name | default (include "pipelines.name" .) }}
+  labels:
+    {{- include "pipelines.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/pipelines/values.yaml
+++ b/charts/pipelines/values.yaml
@@ -38,6 +38,10 @@ persistence:
   selector: {}
   annotations: {}
 
+serviceAccount:
+  enable: true
+  automountServiceAccountToken: false
+
 # -- Node labels for pod assignment.
 nodeSelector: {}
 


### PR DESCRIPTION
Allow us to set service accounts on pipelines as well.

Same as https://github.com/open-webui/helm-charts/pull/110