### PR TITLE
Add namespace explicitly to pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,129 @@
+# Created by https://www.toptal.com/developers/gitignore/api/macos,intellij+all,helm
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,intellij+all,helm
+
+### Helm ###
+# Chart dependencies
+**/charts/*.tgz
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignore everything but code style settings and run configurations
+# that are supposed to be shared within teams.
+
+.idea/*
+
+!.idea/codeStyles
+!.idea/runConfigurations
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,intellij+all,helm

--- a/charts/pipelines/Chart.yaml
+++ b/charts/pipelines/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pipelines
-version: 0.0.5
+version: 0.0.6
 appVersion: "alpha"
 
 home: https://github.com/open-webui/pipelines

--- a/charts/pipelines/templates/_helpers.tpl
+++ b/charts/pipelines/templates/_helpers.tpl
@@ -1,4 +1,15 @@
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts
+*/}}
+{{- define "pipelines.namespace" -}}
+  {{- if .Values.namespaceOverride -}}
+    {{- .Values.namespaceOverride -}}
+  {{- else -}}
+    {{- .Release.Namespace -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*
 Set the name of the Pipelines resources
 */}}
 {{- define "pipelines.name" -}}

--- a/charts/pipelines/templates/deployment.yaml
+++ b/charts/pipelines/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "pipelines.name" . }}
+  namespace: {{ include "pipelines.namespace" . }}
   labels:
     {{- include "pipelines.labels" . | nindent 4 }}
   {{- with .Values.annotations }}
@@ -31,7 +32,6 @@ spec:
       {{- if .Values.serviceAccount.enable }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "pipelines.name" .) }}
       {{- end }}
-
       containers:
       - name: {{ .Chart.Name }}
         {{- with .Values.image }}

--- a/charts/pipelines/templates/pvc.yaml
+++ b/charts/pipelines/templates/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "pipelines.name" . }}
+  namespace: {{ include "pipelines.namespace" . }}
   labels:
     {{- include "pipelines.selectorLabels" . | nindent 4 }}
   {{- with .Values.persistence.annotations }}

--- a/charts/pipelines/templates/service-account.yaml
+++ b/charts/pipelines/templates/service-account.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ .Values.serviceAccount.name | default (include "pipelines.name" .) }}
+  namespace: {{ include "pipelines.namespace" . }}
   labels:
     {{- include "pipelines.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/pipelines/templates/service.yaml
+++ b/charts/pipelines/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "pipelines.name" . }}
+  namespace: {{ include "pipelines.namespace" . }}
   labels:
     {{- include "pipelines.labels" . | nindent 4 }}
     {{- with .Values.service.labels }}

--- a/charts/pipelines/values.yaml
+++ b/charts/pipelines/values.yaml
@@ -1,4 +1,5 @@
 nameOverride: ""
+namespaceOverride: ""
 
 # -- Value of cluster domain
 clusterDomain: cluster.local


### PR DESCRIPTION
The rationale behind this PR is that there are cases where it becomes quite complicated to deploy the application unless the namespace is explicitly provided — for example, when managing the application using a GitOps approach.