### PR TITLE
Add updateStrategy for workload manager

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 4.0.6
+version: 4.1.0
 appVersion: 0.4.7
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 4.0.6](https://img.shields.io/badge/Version-4.0.6-informational?style=flat-square) ![AppVersion: 0.4.7](https://img.shields.io/badge/AppVersion-0.4.7-informational?style=flat-square)
+![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: 0.4.7](https://img.shields.io/badge/AppVersion-0.4.7-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -75,6 +75,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` | Configure pod security context ref: <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-containe> |
 | replicaCount | int | `1` |  |
+| strategy | object | `{}` |  |
 | resources | object | `{}` |  |
 | service | object | `{"annotations":{},"containerPort":8080,"labels":{},"loadBalancerClass":"","nodePort":"","port":80,"type":"ClusterIP"}` | Service values to expose Open WebUI pods to cluster |
 | serviceAccount.annotations | object | `{}` |  |

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -20,6 +20,15 @@ spec:
   selector:
     matchLabels:
       {{- include "open-webui.selectorLabels" . | nindent 6 }}
+  {{- if .Values.strategy }}
+  {{- if .Values.persistence.enabled }}
+  updateStrategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  {{- else }}
+  strategy:
+    {{- toYaml .Values.strategy | nindent 4 }}
+  {{- end }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -37,7 +37,9 @@ clusterDomain: cluster.local
 annotations: {}
 podAnnotations: {}
 replicaCount: 1
-# -- Open WebUI image tags can be found here: https://github.com/open-webui/open-webui/pkgs/container/open-webui
+# -- Strategy for updating the workload manager: deployment or statefulset
+strategy: {}
+# -- Open WebUI image tags can be found here: https://github.com/open-webui/open-webui
 image:
   repository: ghcr.io/open-webui/open-webui
   tag: ""


### PR DESCRIPTION
To add update strategy, choose **key name 'strategy'** for **'Deployment/spec.strategy'** and **'StatefulSet/spec.updateStrategy'.** Update samver from 4.0.6 to 4.1.0 with minor spec changes