### PR TITLE
Fix CI to verify chart installing on test-namespace

### DIFF
--- a/.github/workflows/helm-test-open-webui.yml
+++ b/.github/workflows/helm-test-open-webui.yml
@@ -49,4 +49,6 @@ jobs:
 
       - name: Verify open-webui
         run: |
-          kubectl apply -f open-webui.yaml
+          kubectl create namespace test-namespace
+          kubectl apply --namespace test-namespace -f open-webui.yaml
+          kubectl wait --namespace test-namespace pod/open-webui-0 --for=condition=Ready --timeout=600s


### PR DESCRIPTION
## Opinion

Hello, folks. To resolve #124, we should remove the ambiguity between `default` and `test-namespace`, which stems from the `namespaceOverride` introduced in #122. This commit ensures proper completion of `namespaceOverride`. Proposed changes are followings:

- Create the `test-namespace` namespace.
- Deploy the application in the `test-namespace` namespace instead of the `default` namespace.
- (Optional) Use `kubectl wait` to ensure `pod/open-webui-0` is ready before proceeding.

And local test is following:

![local test result for this PR](https://github.com/user-attachments/assets/eea0479f-8aa8-44a8-ad47-470cbb77542d)

All resources became ready except `open-webui-ollama-test-connection`. That pod would be 'Completed' when recreated so we can ignore it.

If you think that using `kubectl wait` might cause delays or unintended lags, please let me know.

---

## Copilot Summary

This pull request includes changes to the `.github/workflows/helm-test-open-webui.yml` file to enhance the deployment process for the `open-webui`. The most important changes include creating a new namespace, applying the configuration within that namespace, and ensuring the pod is ready before proceeding.

Deployment process improvements:

* [`.github/workflows/helm-test-open-webui.yml`](diffhunk://#diff-e56e3a533bceaee1312f7ca86210883c90d7853a9058e3b30706e81006c535c3L52-R54): Added commands to create a `test-namespace`, apply the `open-webui.yaml` configuration within this namespace, and wait for the `open-webui-0` pod to be ready with a timeout of 600 seconds.