### PR TITLE
fix: Add option to use subPathExpr

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 4.1.0
+version: 4.1.1
 appVersion: 0.4.7
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 4.1.0](https://img.shields.io/badge/Version-4.1.0-informational?style=flat-square) ![AppVersion: 0.4.7](https://img.shields.io/badge/AppVersion-0.4.7-informational?style=flat-square)
+![Version: 4.1.1](https://img.shields.io/badge/Version-4.1.1-informational?style=flat-square) ![AppVersion: 0.4.7](https://img.shields.io/badge/AppVersion-0.4.7-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -47,7 +47,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | copyAppData.resources | object | `{}` |  |
 | extraEnvVars | list | `[{"name":"OPENAI_API_KEY","value":"0p3n-w3bu!"}]` | Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/ |
 | extraEnvVars[0] | object | `{"name":"OPENAI_API_KEY","value":"0p3n-w3bu!"}` | Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/open-webui/open-webui","tag":""}` | Open WebUI image tags can be found here: https://github.com/open-webui/open-webui/pkgs/container/open-webui |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/open-webui/open-webui","tag":""}` | Open WebUI image tags can be found here: https://github.com/open-webui/open-webui |
 | imagePullSecrets | list | `[]` | Configure imagePullSecrets to use private registry ref: <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry> |
 | ingress.additionalHosts | list | `[]` |  |
 | ingress.annotations | object | `{}` | Use appropriate annotations for your Ingress controller, e.g., for NGINX: nginx.ingress.kubernetes.io/rewrite-target: / |
@@ -71,18 +71,20 @@ helm upgrade --install open-webui open-webui/open-webui
 | persistence.size | string | `"2Gi"` |  |
 | persistence.storageClass | string | `""` |  |
 | persistence.subPath | string | `""` | Subdirectory of Open WebUI PVC to mount. Useful if root directory is not empty. |
+| persistence.subPathExpr | string | `""` | Using subdirectory with expanded environment variables. Useful when using multiple replicas. In this case, do not use a subPath. |
 | pipelines.enabled | bool | `true` | Automatically install Pipelines chart to extend Open WebUI functionality using Pipelines: https://github.com/open-webui/pipelines |
 | pipelines.extraEnvVars | list | `[]` | This section can be used to pass required environment variables to your pipelines (e.g. Langfuse hostname) |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` | Configure pod security context ref: <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-containe> |
 | replicaCount | int | `1` |  |
-| strategy | object | `{}` |  |
 | resources | object | `{}` |  |
 | service | object | `{"annotations":{},"containerPort":8080,"labels":{},"loadBalancerClass":"","nodePort":"","port":80,"type":"ClusterIP"}` | Service values to expose Open WebUI pods to cluster |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automountServiceAccountToken | bool | `false` |  |
 | serviceAccount.enable | bool | `true` |  |
 | serviceAccount.name | string | `""` |  |
+| strategy | object | `{}` | Strategy for updating the workload manager: deployment or statefulset |
 | tika.enabled | bool | `false` | Automatically install Apache Tika to extend Open WebUI |
 | tolerations | list | `[]` | Tolerations for pod assignment |
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment |

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -66,6 +66,9 @@ spec:
           {{- if .Values.persistence.subPath }}
           subPath: {{ .Values.persistence.subPath }}
           {{- end }}
+          {{- if .Values.persistence.subPathExpr }}
+          subPath: {{ .Values.persistence.subPathExpr }}
+          {{- end }}
         {{- with .Values.volumeMounts.initContainer }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -99,6 +102,9 @@ spec:
           mountPath: /app/backend/data
           {{- if .Values.persistence.subPath }}
           subPath: {{ .Values.persistence.subPath }}
+          {{- end }}
+          {{- if .Values.persistence.subPathExpr }}
+          subPath: {{ .Values.persistence.subPathExpr }}
           {{- end }}
         {{- with .Values.volumeMounts.container }}
         {{- toYaml . | nindent 8 }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -81,6 +81,9 @@ persistence:
   existingClaim: ""
   # -- Subdirectory of Open WebUI PVC to mount. Useful if root directory is not empty.
   subPath: ""
+  # -- Using subdirectory with expanded environment variables. Useful when using multiple replicas. In this case, do not use a subPath.
+  subPathExpr: ""
+  # subPathExpr: '$(POD_NAME)'
   # -- If using multiple replicas, you must update accessModes to ReadWriteMany
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Support subdirectory with expanded environment variables. Useful when using multiple replicas.

Values used in tests:
```yaml
replicaCount: 2
persistence:
  enabled: true
  size: 2Gi
  subPathExpr: '$(POD_NAME)'
  accessModes:
    - ReadWriteMany
  storageClass: efs
```