### PR TITLE
Add 3 probes to the main container of workload-manager

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 5.0.0
+version: 5.1.0
 appVersion: 0.5.2
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -49,6 +49,9 @@ helm upgrade --install open-webui open-webui/open-webui
 | extraEnvVars[0] | object | `{"name":"OPENAI_API_KEY","value":"0p3n-w3bu!"}` | Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/open-webui/open-webui","tag":""}` | Open WebUI image tags can be found here: https://github.com/open-webui/open-webui |
 | imagePullSecrets | list | `[]` | Configure imagePullSecrets to use private registry ref: <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry> |
+| livenessProbe | object | `{}` | Configure livenessProbe ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes> |
+| readinessProbe | object | `{}` | Configure readinessProbe ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes> |
+| startupProbe | object | `{}` | Configure startupProbe ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes> |
 | ingress.additionalHosts | list | `[]` |  |
 | ingress.annotations | object | `{}` | Use appropriate annotations for your Ingress controller, e.g., for NGINX: nginx.ingress.kubernetes.io/rewrite-target: / |
 | ingress.class | string | `""` |  |

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -87,6 +87,15 @@ spec:
         ports:
         - name: http
           containerPort: {{ .Values.service.containerPort }}
+        {{- with .Values.livenessProbe }}
+        livenessProbe: {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.readinessProbe }}
+        readinessProbe: {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.startupProbe }}
+        startupProbe: {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- with .Values.resources }}
         resources: {{- toYaml . | nindent 10 }}
         {{- end }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -59,6 +59,37 @@ imagePullSecrets: []
 # imagePullSecrets:
 # - name: myRegistryKeySecretName
 
+# -- Probe for liveness of the Open WebUI container
+# ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes>
+livenessProbe: {}
+# livenessProbe:
+#   httpGet:
+#     path: /health
+#     port: http
+#   failureThreshold: 1
+#   periodSeconds: 10
+
+# -- Probe for readiness of the Open WebUI container
+# ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes>
+readinessProbe: {}
+# readinessProbe:
+#   httpGet:
+#     path: /health/db
+#     port: http
+#   failureThreshold: 1
+#   periodSeconds: 10
+
+# -- Probe for startup of the Open WebUI container
+# ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes>
+startupProbe: {}
+# startupProbe:
+#   httpGet:
+#     path: /health
+#     port: http
+#   initialDelaySeconds: 30
+#   periodSeconds: 5
+#   failureThreshold: 20
+
 resources: {}
 
 copyAppData:


### PR DESCRIPTION
Hello, folks. I need to set probes to remove 5xx errors when pods restarted. Please review this. Any feedback would be welcome.

- add `livenessProbe`, `readinessProbe`, `startupProbe` for main container
- add values with commented example values
- add key rows in table of readme
- bump the chart version from `5.0.0` to `5.1.0`