### PR TITLE
Fix 'Pipelines' CI to verify chart installing on test-namespace

### DIFF
--- a/.github/workflows/helm-test-pipelines.yml
+++ b/.github/workflows/helm-test-pipelines.yml
@@ -1,7 +1,6 @@
 name: Check Open WebUI Helm Charts (pipelines)
 
 on:
-  workflow_dispatch:
   pull_request:
     paths:
       - "charts/pipelines/**"

--- a/.github/workflows/helm-test-pipelines.yml
+++ b/.github/workflows/helm-test-pipelines.yml
@@ -1,6 +1,7 @@
 name: Check Open WebUI Helm Charts (pipelines)
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "charts/pipelines/**"
@@ -49,5 +50,7 @@ jobs:
 
       - name: Verify pipelines
         run: |
-          kubectl apply -f pipelines.yaml
-
+          kubectl create namespace test-namespace
+          kubectl apply --namespace test-namespace -f pipelines.yaml
+          PIPELINE_POD=$(kubectl get --namespace test-namespace pod -L app.kubernetes.io/component=pipelines -o jsonpath='{.items[*].metadata.name}')
+          kubectl wait --namespace test-namespace pod/${PIPELINE_POD} --for=condition=Ready --timeout=600s

--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
 
-Pipelines: UI-Agnostic OpenAI API Plugin Framework
+Pipelines: UI-Agnostic OpenAI API Plugin Framework 🚀
 
 **Homepage:** <https://github.com/open-webui/pipelines>
 

--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -2,7 +2,7 @@
 
 ![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
 
-Pipelines: UI-Agnostic OpenAI API Plugin Framework 🚀
+Pipelines: UI-Agnostic OpenAI API Plugin Framework
 
 **Homepage:** <https://github.com/open-webui/pipelines>
 


### PR DESCRIPTION
## Opinion

Hello, folks again. To resolve #133, I change CI files remove the ambiguity between `default` and `test-namespace` (very similar to #125). Proposed changes are followings:

- Create the `test-namespace` namespace.
- Deploy the application in the `test-namespace` namespace instead of the `default` namespace.
- Use `kubectl wait` to ensure `pod/pipelines-##########-#####` is ready before proceeding.

I tested proposed workflow in forked repository. Please check my commits. thx

---

## Copilot Summary

This pull request includes a change to the Helm test pipelines workflow to improve the verification process by adding a namespace creation step and ensuring the pipeline pod is ready before proceeding.

Key changes:

* `.github/workflows/helm-test-pipelines.yml`: 
  - Added a command to create a new namespace `test-namespace` before applying the `pipelines.yaml` file.
  - Modified the `kubectl apply` command to use the newly created namespace.
  - Introduced commands to get the pipeline pod name and wait for the pod to be ready before continuing.
