### PR TITLE
Fix 'helm-release' CI to disabling chart release for forked repos

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -44,6 +44,7 @@ jobs:
 
   release:
     #needs: semantic-release
+    if: github.repository == 'open-webui/helm-charts'
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
Hello, folks. I'd like to suggest disabling chart releases for forked repositories by default.

After forking this repository and enabling Actions, I noticed that the `main` branch's workflow attempted to release charts using unconfigured or void variables, causing the pipeline to fail. This behavior seems common across other repositories with similar setups.

The proposed change is simple: it adds a repository slug check to ensure the workflow only proceeds in the original repository unless explicitly configured otherwise. This helps prevent unnecessary actions and failures in forked repositories. If someone wants to release forked chart, they can comment the `if: ...` line.

But it’s a simple but significant change, so rejecting this is totally okay. Please check it, and any feedback would be welcome.