### PR TITLE
Add extra resources

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 5.1.1
+version: 5.2.0
 appVersion: 0.5.4
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 5.2.0
+version: 5.3.0
 appVersion: 0.5.4
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -47,6 +47,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | copyAppData.resources | object | `{}` |  |
 | extraEnvVars | list | `[{"name":"OPENAI_API_KEY","value":"0p3n-w3bu!"}]` | Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/ |
 | extraEnvVars[0] | object | `{"name":"OPENAI_API_KEY","value":"0p3n-w3bu!"}` | Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines |
+| extraResources | list | `[]` | Extra resources to deploy with Open WebUI |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/open-webui/open-webui","tag":""}` | Open WebUI image tags can be found here: https://github.com/open-webui/open-webui |
 | imagePullSecrets | list | `[]` | Configure imagePullSecrets to use private registry ref: <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry> |
 | ingress.additionalHosts | list | `[]` |  |

--- a/charts/open-webui/templates/extra-resources.yaml
+++ b/charts/open-webui/templates/extra-resources.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.extraResources }}
+{{- range .Values.extraResources }}
+---
+{{ toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -205,3 +205,13 @@ containerSecurityContext:
   #     - ALL
   # seccompProfile:
   #   type: "RuntimeDefault"
+
+# -- Extra resources to deploy with Open WebUI
+extraResources:
+  []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: example-configmap
+  #   data:
+  #     example-key: example-value

--- a/charts/pipelines/Chart.yaml
+++ b/charts/pipelines/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pipelines
-version: 0.0.6
+version: 0.1.0
 appVersion: "alpha"
 
 home: https://github.com/open-webui/pipelines

--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -35,6 +35,7 @@ helm upgrade --install open-webui open-webui/pipelines
 | clusterDomain | string | `"cluster.local"` | Value of cluster domain |
 | extraEnvVars | list | `[{"name":"PIPELINES_URLS","value":"https://github.com/open-webui/pipelines/blob/main/examples/filters/detoxify_filter_pipeline.py"}]` | Additional environments variables on the output Deployment definition. These are used to pull initial Pipeline files, and help configure Pipelines with required values (e.g. Langfuse API keys) |
 | extraEnvVars[0] | object | `{"name":"PIPELINES_URLS","value":"https://github.com/open-webui/pipelines/blob/main/examples/filters/detoxify_filter_pipeline.py"}` | Example pipeline to pull and load on deployment startup, see current pipelines here: https://github.com/open-webui/pipelines/blob/main/examples |
+| extraResources | list | `[]` | Extra resources to deploy with Open WebUI Pipelines |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"ghcr.io/open-webui/pipelines"` |  |
 | image.tag | string | `"main"` |  |

--- a/charts/pipelines/templates/extra-resources.yaml
+++ b/charts/pipelines/templates/extra-resources.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.extraResources }}
+{{- range .Values.extraResources }}
+---
+{{ toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/charts/pipelines/values.yaml
+++ b/charts/pipelines/values.yaml
@@ -87,3 +87,13 @@ extraEnvVars:
   #       key: secret-key
   # - name: LANGFUSE_HOST
   #   value: https://us.cloud.langfuse.com
+
+# -- Extra resources to deploy with Open WebUI Pipelines
+extraResources:
+  []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: example-configmap
+  #   data:
+  #     example-key: example-value


### PR DESCRIPTION
## Opinion
Hello, folks. I suggest applying values for `extraResources` in the open-webui and pipelines charts. Adding this will allow us to include extra resources such as `ConfigMaps` and `SealedSecrets` in the cluster.

### What we can do with this
- We can deploy resources together for open-webui without extra deployment.
  - Add static configuration from users
  - Add synced configuration from other k8s operators
  - Add secrets for secure GitOps

### Usage
**Default**
No resources added from `extraResources`

values.yaml:
```yaml
extraResources:
  []
```

**Deploy ConfigMap and SealedSecret**
- Static resources are added to the cluster.
- Especially useful for synced/encrypted resources for other operators
  - example 1: from [emberstack/kubernetes-reflector](https://github.com/emberstack/kubernetes-reflector)
  - example 2: from [bitnami/sealed-secrets](https://github.com/bitnami-labs/sealed-secrets)

values.yaml:
```yaml
extraResources:
  # Static resources
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: open-webui-example-configmap
    data:
      replicaCount: "3"
      backup: "...."

  # Synced resources
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: open-webui-synced-configmap
      annotations:
        reflector.v1.k8s.emberstack.com/reflects: "etcd-system/etcd-cluster-config"
    data: {} # Updated automatically by other operators
  - apiVersion: v1
    kind: Secret
    metadata:
      name: open-webui-synced-secret
      annotations:
        reflector.v1.k8s.emberstack.com/reflects: "etcd-system/etcd-cluster-secret"
    data: {} # Updated automatically by other operators

  # Encrypted resources
  - apiVersion: bitnami.com/v1alpha1
    kind: SealedSecret
    metadata:
      name: open-webui-example-creds
    spec:
      template:
        type: Opaque
        metadata:
          name: open-webui-example-creds
      encryptedData:
        redis.url: "batf5ogUFBRp2o7Sdzz6NTx...<skip>"
        vectordb.uri: "iTcLhC/dzUKQOEsrbatf5ogUFBRp2o7Sdzz...<skip>"
```

Please give me any advise.

Thank you!

---

## Copilot Summary
This pull request includes several updates to the `open-webui` and `pipelines` charts, primarily focusing on adding support for extra resources and updating chart versions.

### Updates to `open-webui` chart:

* **Version Update:**
  * [`charts/open-webui/Chart.yaml`](diffhunk://#diff-fd1c91305ae5ec8685061c0996edf27e8fdf180534d5c02219ed03418765f624L3-R3): Updated the chart version from `5.1.1` to `5.2.0`.

* **Extra Resources Support:**
  * [`charts/open-webui/README.md`](diffhunk://#diff-f923dfcf40b056769f08b1c67dd4b43fde108d4ddbea3c27e725070d28e9003dR50): Added a description for `extraResources` to the table of configurable parameters.
  * [`charts/open-webui/templates/extra-resources.yaml`](diffhunk://#diff-f0c272f221851f970d0ea8653fe01d45ed19e7a370ae68adb89a86f839ab6b95R1-R6): Introduced a new template file to handle extra resources deployment.
  * [`charts/open-webui/values.yaml`](diffhunk://#diff-bbcc9d78d9f50476a0b1619e8a1e9a2377f05aeae7aed666433186247f00f30dR208-R217): Added a new section for `extraResources` configuration.

### Updates to `pipelines` chart:

* **Version Update:**
  * [`charts/pipelines/Chart.yaml`](diffhunk://#diff-a67745d413b65d63b14f6ae4028d539144d46075f798f1f6e7c3fdb3ebcc3d2bL3-R3): Updated the chart version from `0.0.6` to `0.1.0`.

* **Extra Resources Support:**
  * [`charts/pipelines/README.md`](diffhunk://#diff-0edea66306aaa9736640d701b506d03da7309881c898c9a5baeb97a9ec967642R38): Added a description for `extraResources` to the table of configurable parameters.
  * [`charts/pipelines/templates/extra-resources.yaml`](diffhunk://#diff-f0c272f221851f970d0ea8653fe01d45ed19e7a370ae68adb89a86f839ab6b95R1-R6): Introduced a new template file to handle extra resources deployment.
  * [`charts/pipelines/values.yaml`](diffhunk://#diff-a72b147683a7e33445c4ada00218ca34f57ff399b42135e9329fb4127ed16bedR90-R99): Added a new section for `extraResources` configuration.