### PR TITLE
Add helm notes (Helper Message)

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 5.1.1
+version: 5.2.0
 appVersion: 0.5.4
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/templates/NOTES.txt
+++ b/charts/open-webui/templates/NOTES.txt
@@ -1,0 +1,80 @@
+{{- `
+🎉 Welcome to Open WebUI!!
+  ___                    __        __   _     _   _ ___ 
+ / _ \ _ __   ___ _ __  \ \      / /__| |__ | | | |_ _|
+| | | | '_ \ / _ \ '_ \  \ \ /\ / / _ \ '_ \| | | || | 
+| |_| | |_) |  __/ | | |  \ V  V /  __/ |_) | |_| || | 
+ \___/| .__/ \___|_| |_|   \_/\_/ \___|_.__/ \___/|___|
+      |_|                                               
+` }}
+v{{ .Chart.AppVersion }} - building the best open-source AI user interface.
+ - Chart Version: v{{ .Chart.Version }}
+ - Project URL 1: {{ .Chart.Home }}
+ - Project URL 2: https://github.com/open-webui/open-webui
+ - Documentation: https://docs.openwebui.com/
+ - Chart URL: https://github.com/open-webui/helm-charts
+
+Open WebUI is a web-based user interface that works with Ollama, OpenAI, Claude 3, Gemini and more.
+This interface allows you to easily interact with local AI models.
+
+1. Deployment Information:
+  - Chart Name: {{ .Chart.Name }}
+  - Release Name: {{ .Release.Name }}
+  - Namespace: {{ .Release.Namespace }}
+
+2. Access the Application:
+{{- if contains "ClusterIP" .Values.service.type }}
+  Access via ClusterIP service:
+
+    export LOCAL_PORT=8080
+    export POD_NAME=$(kubectl get pods -n {{ .Release.Namespace }} -l "app.kubernetes.io/component={{ include "open-webui.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+    export CONTAINER_PORT=$(kubectl get pod -n {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+    kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME $LOCAL_PORT:$CONTAINER_PORT
+    echo "Visit http://127.0.0.1:$LOCAL_PORT to use your application"
+
+  Then, access the application at: http://127.0.0.1:$LOCAL_PORT or http://localhost:8080
+
+{{- else if contains "NodePort" .Values.service.type }}
+  Access via NodePort service:
+    export NODE_PORT=$(kubectl get -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "open-webui.name" . }})
+    export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
+    echo http://$NODE_IP:$NODE_PORT
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  Access via LoadBalancer service:
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  NOTE: The external address format depends on your cloud provider:
+    - AWS: Will return a hostname (e.g., xxx.elb.amazonaws.com)
+    - GCP/Azure: Will return an IP address
+  You can watch the status by running:
+
+    kubectl get -n {{ .Release.Namespace }} svc {{ include "open-webui.name" . }} --watch
+    export EXTERNAL_IP=$(kubectl get -n {{ .Release.Namespace }} svc {{ include "open-webui.name" . }} -o jsonpath="{.status.loadBalancer.ingress[0].hostname:-.status.loadBalancer.ingress[0].ip}")
+    echo http://$EXTERNAL_IP:{{ .Values.service.port }}
+
+{{- else if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+   Ingress is enabled. Access the application at:
+   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+3. Useful Commands:
+  - Check deployment status:
+      helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+  
+  - Get detailed information:
+      helm get all {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+  - View logs:
+    {{- if .Values.persistence.enabled }}
+      kubectl logs -f statefulset/{{ include "open-webui.name" . }} -n {{ .Release.Namespace }}
+    {{- else }}
+      kubectl logs -f deployment/{{ include "open-webui.name" . }} -n {{ .Release.Namespace }}
+    {{- end }}
+
+4. Cleanup:
+  - Uninstall the deployment:
+      helm uninstall {{ .Release.Name }}

--- a/charts/open-webui/templates/NOTES.txt
+++ b/charts/open-webui/templates/NOTES.txt
@@ -51,14 +51,11 @@ This interface allows you to easily interact with local AI models.
     kubectl get -n {{ .Release.Namespace }} svc {{ include "open-webui.name" . }} --watch
     export EXTERNAL_IP=$(kubectl get -n {{ .Release.Namespace }} svc {{ include "open-webui.name" . }} -o jsonpath="{.status.loadBalancer.ingress[0].hostname:-.status.loadBalancer.ingress[0].ip}")
     echo http://$EXTERNAL_IP:{{ .Values.service.port }}
-
-{{- else if .Values.ingress.enabled }}
-{{- range $host := .Values.ingress.hosts }}
-  {{- range .paths }}
-   Ingress is enabled. Access the application at:
-   http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
-  {{- end }}
 {{- end }}
+
+{{- if .Values.ingress.enabled }}
+
+  Ingress is enabled. Access the application at: http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}
 {{- end }}
 
 3. Useful Commands:
@@ -77,4 +74,4 @@ This interface allows you to easily interact with local AI models.
 
 4. Cleanup:
   - Uninstall the deployment:
-      helm uninstall {{ .Release.Name }}
+      helm uninstall {{ .Release.Name }} -n {{ .Release.Namespace }}


### PR DESCRIPTION
## Opinion

To resolve #66, I made pilot helm `NOTES.txt` for open-webui chart (as Helper Message).

### Example: open-webui notes with ingress+tls
This is an example command
```sh
helm upgrade --install --cleanup-on-fail \
    -n owui-ingress --create-namespace \
    --set ingress.enabled=true \
    --set ingress.class=nginx \
    --set ingress.host=owui.example.com \
    --set ingress.tls=true \
    --set ingress.existingSecret=owui-tls \
    owui-ingress .
```

And this is corresponding note (helper message)
```sh
🎉 Welcome to Open WebUI!!
  ___                    __        __   _     _   _ ___ 
 / _ \ _ __   ___ _ __  \ \      / /__| |__ | | | |_ _|
| | | | '_ \ / _ \ '_ \  \ \ /\ / / _ \ '_ \| | | || | 
| |_| | |_) |  __/ | | |  \ V  V /  __/ |_) | |_| || | 
 \___/| .__/ \___|_| |_|   \_/\_/ \___|_.__/ \___/|___|
      |_|                                               

v0.5.4 - building the best open-source AI user interface.
 - Chart Version: v5.2.0
 - Project URL 1: https://www.openwebui.com/
 - Project URL 2: https://github.com/open-webui/open-webui
 - Documentation: https://docs.openwebui.com/
 - Chart URL: https://github.com/open-webui/helm-charts

Open WebUI is a web-based user interface that works with Ollama, OpenAI, Claude 3, Gemini and more.
This interface allows you to easily interact with local AI models.

1. Deployment Information:
  - Chart Name: open-webui
  - Release Name: owui-ingress
  - Namespace: owui-ingress

2. Access the Application:
  Access via ClusterIP service:

    export LOCAL_PORT=8080
    export POD_NAME=$(kubectl get pods -n owui-ingress -l "app.kubernetes.io/component=open-webui" -o jsonpath="{.items[0].metadata.name}")
    export CONTAINER_PORT=$(kubectl get pod -n owui-ingress $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
    kubectl -n owui-ingress port-forward $POD_NAME $LOCAL_PORT:$CONTAINER_PORT
    echo "Visit http://127.0.0.1:$LOCAL_PORT to use your application"

  Then, access the application at: http://127.0.0.1:$LOCAL_PORT or http://localhost:8080

  Ingress is enabled. Access the application at: https://owui.example.com

3. Useful Commands:
  - Check deployment status:
      helm status owui-ingress -n owui-ingress
  
  - Get detailed information:
      helm get all owui-ingress -n owui-ingress

  - View logs:
      kubectl logs -f statefulset/open-webui -n owui-ingress

4. Cleanup:
  - Uninstall the deployment:
      helm uninstall owui-ingress -n owui-ingress
```
![image](https://github.com/user-attachments/assets/75f1a608-7fb8-4fd3-a8d3-0b647abfec98)


### Demo: open-webui notes with various settings
I recorded for 4 scenarios with following codes:
```
git clone -b feat/owui-notes https://github.com/jyje/owui-helm-charts
cd owui-helm-charts/charts/open-webui

kind create cluster --name owui-notes
kubectl config use-context kind-owui-notes

# 1. Install the default chart
helm upgrade --install --cleanup-on-fail \
    -n owui-default --create-namespace \
    owui-default .

# 2. Install the deploy chart
helm upgrade --install --cleanup-on-fail \
    -n owui-deploy --create-namespace \
    --set persistence.enabled=false \
    owui-deploy .

# 3. Install the nodeport chart
helm upgrade --install --cleanup-on-fail \
    -n owui-nodeport --create-namespace \
    --set service.type=NodePort \
    owui-nodeport .

# 4. Install the loadbalancer chart
helm upgrade --install --cleanup-on-fail \
    -n owui-loadbalancer --create-namespace \
    --set service.type=LoadBalancer \
    owui-loadbalancer .
```

Please check **Demo in asciicast**:
[![asciicast](https://asciinema.org/a/698210.svg)](https://asciinema.org/a/698210)


If there are typo or good suggestion, please let me know.

---
## Copilot Summary

This pull request includes updates to the Open WebUI Helm chart, specifically enhancing the user experience with the NOTES.txt file and updating the chart version.

### Chart version update:
* [`charts/open-webui/Chart.yaml`](diffhunk://#diff-fd1c91305ae5ec8685061c0996edf27e8fdf180534d5c02219ed03418765f624L3-R3): Updated the chart version from 5.1.1 to 5.2.0.

### Enhanced user experience:
* [`charts/open-webui/templates/NOTES.txt`](diffhunk://#diff-20bc107c4eba717bf4383c76901e222ed10ff92b72db5dabdaea353ef6f5cf76R1-R80): Added a detailed welcome message and instructions for accessing and managing the Open WebUI application, including deployment information, access methods, useful commands, and cleanup instructions.