### PR TITLE
Fix OPENAI_API_BASE_URL configuration logic

### DIFF
--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -121,10 +121,10 @@ spec:
           value: "False"
         {{- end }}
         - name: "OPENAI_API_BASE_URL"
-        {{- if .Values.pipelines.enabled }}
-          value: {{ include "pipelines.serviceEndpoint" . }}
-        {{- else if .Values.openaiBaseApiUrl }}
+        {{- if .Values.openaiBaseApiUrl }}
           value: {{ .Values.openaiBaseApiUrl | quote }}
+        {{- else if .Values.pipelines.enabled }}
+          value: {{ include "pipelines.serviceEndpoint" . }}
         {{- end }}
         {{- if .Values.extraEnvVars }}
           {{- toYaml .Values.extraEnvVars | nindent 8 }}


### PR DESCRIPTION
Correct the logic for setting the OPENAI_API_BASE_URL to prioritize the openaiBaseApiUrl value over the pipelines service endpoint.

----
This pull request includes a change to the `charts/open-webui/templates/workload-manager.yaml` file to adjust the order of conditional checks for setting the `OPENAI_API_BASE_URL` environment variable. The most important change is:

* [`charts/open-webui/templates/workload-manager.yaml`](diffhunk://#diff-105fd9176f116a9143ec3870cadd8a3e9b2407af00d6c214a0d4259833dc31d7L124-R127): Modified the order of conditional checks to prioritize `openaiBaseApiUrl` over `pipelines.enabled` when setting the `OPENAI_API_BASE_URL` environment variable.