### PR TITLE
Add managed certificate support and update ingress configuration for GKE

### DIFF
--- a/charts/open-webui/templates/managed-cert.yaml
+++ b/charts/open-webui/templates/managed-cert.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.managedCertificate.enabled }}
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: {{ .Values.managedCertificate.name | default "mydomain-cert" }}
+spec:
+  domains:
+    {{- range .Values.managedCertificate.domains }}
+    - {{ . | quote }}
+    {{- end }}
+{{- end }}

--- a/charts/open-webui/values-gke-min.yaml
+++ b/charts/open-webui/values-gke-min.yaml
@@ -3,7 +3,7 @@ namespaceOverride: ""
 
 ollama:
   # -- Automatically install Ollama Helm chart from https://otwld.github.io/ollama-helm/. Use [Helm Values](https://github.com/otwld/ollama-helm/#helm-values) to configure
-  enabled: true
+  enabled: false
   # -- If enabling embedded Ollama, update fullnameOverride to your desired Ollama name value, or else it will use the default ollama.name value from the Ollama chart
   fullnameOverride: "open-webui-ollama"
   # -- Example Ollama configuration with nvidia GPU enabled, automatically downloading a model, and deploying a PVC for model persistence
@@ -21,7 +21,7 @@ ollama:
 
 pipelines:
   # -- Automatically install Pipelines chart to extend Open WebUI functionality using Pipelines: https://github.com/open-webui/pipelines
-  enabled: true
+  enabled: false
   # -- This section can be used to pass required environment variables to your pipelines (e.g. Langfuse hostname)
   extraEnvVars: []
 
@@ -206,7 +206,7 @@ topologySpreadConstraints: []
 
 # -- Service values to expose Open WebUI pods to cluster
 service:
-  type: ClusterIP
+  type: LoadBalancer   # changed from ClusterIP to LoadBalancer for external access on GKE
   annotations: {}
   port: 80
   containerPort: 8080

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -164,16 +164,16 @@ ingress:
   enabled: false
   class: ""
   # -- Use appropriate annotations for your Ingress controller, e.g., for NGINX:  
-  annotations: 
-    # Example for GKE Ingress
-    kubernetes.io/ingress.class: "gce"
-    kubernetes.io/ingress.global-static-ip-name: "open-webui-external-ip"   #  you need to create this address in GCP console
-    # Force HTTP to redirect to HTTPS
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/permanent-redirect: "https://chat.example.com"
-    networking.gke.io/managed-certificates: "mydomain-chat-cert"
-    # nginx.ingress.kubernetes.io/rewrite-target: / 
+  annotations: {}
+  #   # Example for GKE Ingress
+  #   kubernetes.io/ingress.class: "gce"
+  #   kubernetes.io/ingress.global-static-ip-name: "open-webui-external-ip"   #  you need to create this address in GCP console
+  #   # Force HTTP to redirect to HTTPS
+  #   nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+  #   nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  #   nginx.ingress.kubernetes.io/permanent-redirect: "https://chat.example.com"
+  #   networking.gke.io/managed-certificates: "mydomain-chat-cert"
+  #   # nginx.ingress.kubernetes.io/rewrite-target: / 
   host: "chat.example.com"  # update to your real domain 
   additionalHosts: []
   tls: false

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -161,7 +161,7 @@ managedCertificate:
     - chat.example.com # update to your real domain
 
 ingress:
-  enabled: true
+  enabled: false
   class: ""
   # -- Use appropriate annotations for your Ingress controller, e.g., for NGINX:  
   annotations: 

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -155,7 +155,7 @@ copyAppData:
   resources: {}
 
 managedCertificate:
-  enabled: true
+  enabled: false
   name: "mydomain-chat-cert"  # You can override this name if needed
   domains:
     - chat.example.com # update to your real domain


### PR DESCRIPTION
This pull request introduces small enhancement to the Open WebUI Helm chart, including the addition of managed certificate support and various ingress configuration options needed for https for improved deployment, while minimizing changes in the default values.yaml.


Key changes include:

### Managed Certificate Support:
* Added a `ManagedCertificate` resource in `managed-cert.yaml` to enable automatic certificate management for specified domains.

### Configuration Enhancements:
* Added `values-gke-min.yaml` to include working gke environment for "minimal" set up - only the main `open-webui `stateful set with no `Ollama`, `Pipelines`, `Tika`, `Redis`, and `WebSocket` support. This setup works with openai and it good as a starting point for deployment in GKE for a new comer. This meant to help users to overcome the issues I faced as new comer to add HTTPS.
* Added ingress with annotations  for working with HTTPS, including SSL redirection and managed certificates, but left it disabled as it was in order not to change the default deployment at all.

These changes collectively improve the flexibility and ease of deploying Open WebUI on GKE with managed certificates and other configurable components.