### PR TITLE
feat: enable annotations in redis pods

### DIFF
--- a/charts/open-webui/templates/websocket-redis.yaml
+++ b/charts/open-webui/templates/websocket-redis.yaml
@@ -21,6 +21,10 @@ spec:
     metadata:
       labels:
         {{- include "websocket.redis.labels" . | nindent 8 }}
+      annotations:
+        {{- with .Values.websocket.redis.pods.annotations }}
+        {{- toYaml . | nindent 4 }}
+        {{- end }}
     spec:
       containers:
       - name: {{ .Values.websocket.redis.name }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -52,6 +52,10 @@ websocket:
     labels: {}
     # -- Redis annotations
     annotations: {}
+    # -- Redis pod
+    pods:
+      # -- Redis pod annotations
+      annotations: {}
     # -- Redis image
     image:
       repository: redis


### PR DESCRIPTION
## Description
This change enables add annotations in redis pod level.

### Issue:
You have enabled Istio with `sidecar.istio.io/inject: "true"` in your Cluster by default for all Pods. This change allows you to disable Istio using annotations.