### PR TITLE
feat: [pipelines] add option for use hpa and pdb

### DIFF
--- a/charts/pipelines/Chart.yaml
+++ b/charts/pipelines/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pipelines
-version: 0.1.0
+version: 0.2.0
 appVersion: "alpha"
 
 home: https://github.com/open-webui/pipelines

--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -1,6 +1,6 @@
 # pipelines
 
-![Version: 0.0.6](https://img.shields.io/badge/Version-0.0.6-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
 
 Pipelines: UI-Agnostic OpenAI API Plugin Framework
 
@@ -32,6 +32,13 @@ helm upgrade --install open-webui open-webui/pipelines
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for pod assignment |
 | annotations | object | `{}` |  |
+| autoscaling | object | `{"behavior":{},"enabled":false,"maxReplicas":5,"metrics":[],"minReplicas":1,"targetCPUUtilizationPercentage":50,"targetMemoryUtilizationPercentage":90}` | Configure horizontal pod autoscale (hpa) ref: <https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/> |
+| autoscaling.behavior | object | `{}` | Configures the scaling behavior of the target in both Up and Down directions. |
+| autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaler |
+| autoscaling.maxReplicas | int | `5` | Maximum number of replicas |
+| autoscaling.minReplicas | int | `1` | Minimum number of replicas |
+| autoscaling.targetCPUUtilizationPercentage | int | `50` | Average CPU utilization percentage |
+| autoscaling.targetMemoryUtilizationPercentage | int | `90` | Average memory utilization percentage |
 | clusterDomain | string | `"cluster.local"` | Value of cluster domain |
 | extraEnvVars | list | `[{"name":"PIPELINES_URLS","value":"https://github.com/open-webui/pipelines/blob/main/examples/filters/detoxify_filter_pipeline.py"}]` | Additional environments variables on the output Deployment definition. These are used to pull initial Pipeline files, and help configure Pipelines with required values (e.g. Langfuse API keys) |
 | extraEnvVars[0] | object | `{"name":"PIPELINES_URLS","value":"https://github.com/open-webui/pipelines/blob/main/examples/filters/detoxify_filter_pipeline.py"}` | Example pipeline to pull and load on deployment startup, see current pipelines here: https://github.com/open-webui/pipelines/blob/main/examples |
@@ -49,6 +56,12 @@ helm upgrade --install open-webui open-webui/pipelines
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
 | nodeSelector | object | `{}` | Node labels for pod assignment. |
+| pdb | object | `{"annotations":{},"enabled":false,"labels":{},"maxUnavailable":"","minAvailable":1}` | Deploy a PodDisruptionBudget ref: <https://kubernetes.io/docs/tasks/run-application/configure-pdb/> |
+| pdb.annotations | object | `{}` | Annotations to be added to pdb |
+| pdb.enabled | bool | `false` | Enable PodDisruptionBudget |
+| pdb.labels | object | `{}` | Labels to be added to pdb |
+| pdb.maxUnavailable | string | `""` | Number of pods that are unavailable after eviction as number or percentage (eg.: 50%). # Has higher precedence over `controller.pdb.minAvailable` |
+| pdb.minAvailable | int | `1` | Number of pods that are available after eviction as number or percentage (eg.: 50%) |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | If using multiple replicas, you must update accessModes to ReadWriteMany |
 | persistence.annotations | object | `{}` |  |
 | persistence.enabled | bool | `true` |  |

--- a/charts/pipelines/templates/hpa.yaml
+++ b/charts/pipelines/templates/hpa.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "pipelines.name" . }}
+  namespace: {{ include "pipelines.namespace" . }}
+  labels:
+    {{- include "pipelines.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "pipelines.name" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+  {{- with .Values.autoscaling.metrics }}
+    {{- toYaml . | nindent 4 }}
+  {{- else }}
+    {{- with .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+    {{- with .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.autoscaling.behavior }}
+  behavior:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/pipelines/templates/pdb.yaml
+++ b/charts/pipelines/templates/pdb.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pipelines.name" . }}
+  namespace: {{ include "pipelines.namespace" . }}
+  labels:
+    {{- include "pipelines.labels" . | nindent 4 }}
+    {{- with .Values.pdb.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.pdb.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- with .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- else }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pipelines.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/pipelines/values.yaml
+++ b/charts/pipelines/values.yaml
@@ -69,24 +69,68 @@ extraEnvVars:
     value: "https://github.com/open-webui/pipelines/blob/main/examples/filters/detoxify_filter_pipeline.py"
   # - name: PIPELINES_API_KEY
   #   valueFrom:
-  #     secretKeyRef: 
+  #     secretKeyRef:
   #       name: pipelines-keys
   #       key: pipelines-api-key
   # -- Langfuse example, including values used in Langfuse filter to connect
   # - name: PIPELINES_URLS
-  #   value: "https://github.com/open-webui/pipelines/blob/main/examples/filters/langfuse_filter_pipeline.py"  
+  #   value: "https://github.com/open-webui/pipelines/blob/main/examples/filters/langfuse_filter_pipeline.py"
   # - name: LANGFUSE_PUBLIC_KEY
   #   valueFrom:
-  #     secretKeyRef: 
+  #     secretKeyRef:
   #       name: langfuse-keys
   #       key: public-key
   # - name: LANGFUSE_SECRET_KEY
   #   valueFrom:
-  #     secretKeyRef: 
+  #     secretKeyRef:
   #       name: langfuse-keys
   #       key: secret-key
   # - name: LANGFUSE_HOST
   #   value: https://us.cloud.langfuse.com
+
+# -- Configure horizontal pod autoscale (hpa)
+# ref: <https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/>
+autoscaling:
+  # -- Enable Horizontal Pod Autoscaler
+  enabled: false
+  # -- Minimum number of replicas
+  minReplicas: 1
+  # -- Maximum number of replicas
+  maxReplicas: 5
+  # -- Average CPU utilization percentage
+  targetCPUUtilizationPercentage: 50
+  # -- Average memory utilization percentage
+  targetMemoryUtilizationPercentage: 90
+  # -- Configures the scaling behavior of the target in both Up and Down directions.
+  behavior: {}
+    # scaleDown:
+    #  stabilizationWindowSeconds: 300
+    #  policies:
+    #   - type: Pods
+    #     value: 1
+    #     periodSeconds: 180
+    # scaleUp:
+    #   stabilizationWindowSeconds: 300
+    #   policies:
+    #   - type: Pods
+    #     value: 2
+    #     periodSeconds: 60
+  metrics: []
+
+# -- Deploy a PodDisruptionBudget
+# ref: <https://kubernetes.io/docs/tasks/run-application/configure-pdb/>
+pdb:
+  # -- Enable PodDisruptionBudget
+  enabled: false
+  # -- Labels to be added to pdb
+  labels: {}
+  # -- Annotations to be added to pdb
+  annotations: {}
+  # -- Number of pods that are available after eviction as number or percentage (eg.: 50%)
+  minAvailable: 1
+  # -- Number of pods that are unavailable after eviction as number or percentage (eg.: 50%).
+  ## Has higher precedence over `controller.pdb.minAvailable`
+  maxUnavailable: ""
 
 # -- Extra resources to deploy with Open WebUI Pipelines
 extraResources:


### PR DESCRIPTION
Add option for use hpa and pdb

I successfully tested remotely using the values:
```yaml
replicaCount: 2

persistence:
  enabled: false

autoscaling:
  enabled: true
  minReplicas: 2
  maxReplicas: 5

pdb:
  enabled: true

resources:
  requests:
    cpu: 0.5
    memory: 1Gi
```    