### PR TITLE
Update open-webui to v0.5.11

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 5.10.1
-appVersion: 0.5.10
+version: 5.11.0
+appVersion: 0.5.11
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 5.10.0](https://img.shields.io/badge/Version-5.10.0-informational?style=flat-square) ![AppVersion: 0.5.10](https://img.shields.io/badge/AppVersion-0.5.10-informational?style=flat-square)
+![Version: 5.11.0](https://img.shields.io/badge/Version-5.11.0-informational?style=flat-square) ![AppVersion: 0.5.11](https://img.shields.io/badge/AppVersion-0.5.11-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
Hello, guys! by https://github.com/open-webui/open-webui/releases/tag/v0.5.11, we need to bump app and chart version.

please take a look

## PR
**chore: update open-webui to v0.5.11**
- update open-webui
    - app: from v0.5.10 to v0.5.11
    - chart: from 5.10.0 to 5.11.0
- no dependency update (not founded from each remotes)