### PR TITLE
Update open-webui to v0.5.13

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 5.13.0
-appVersion: 0.5.12
+version: 5.14.0
+appVersion: 0.5.13
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 5.13.0](https://img.shields.io/badge/Version-5.13.0-informational?style=flat-square) ![AppVersion: 0.5.12](https://img.shields.io/badge/AppVersion-0.5.12-informational?style=flat-square)
+![Version: 5.14.0](https://img.shields.io/badge/Version-5.14.0-informational?style=flat-square) ![AppVersion: 0.5.13](https://img.shields.io/badge/AppVersion-0.5.13-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
Hello, guys!

by https://github.com/open-webui/open-webui/releases/tag/v0.5.13
we need to bump app and chart version.

and... v0.5.14 was released for bugfix in moment. I will follow up for the latest release

## PR
**chore: update open-webui to v0.5.13 (chart 5.14.0)**
- update open-webui
    - app: from v0.5.12 to v0.5.13
    - chart: from 5.13.0 to 5.14.0
- no dependency update
