### PR TITLE
feat: [pipelines] add volumeMounts and volumes

### DIFF
--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -70,6 +70,8 @@ helm upgrade --install open-webui open-webui/pipelines
 | serviceAccount.automountServiceAccountToken | bool | `false` |  |
 | serviceAccount.enable | bool | `true` |  |
 | tolerations | list | `[]` | Tolerations for pod assignment |
+| volumeMounts | list | `[]` | Configure container volume mounts |
+| volumes | list | `[]` | Configure pod volumes |
 
 ----------------------------------------------
 

--- a/charts/pipelines/templates/deployment.yaml
+++ b/charts/pipelines/templates/deployment.yaml
@@ -50,6 +50,9 @@ spec:
         volumeMounts:
         - name: data
           mountPath: /app/pipelines
+        {{- with .Values.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         env:
         {{- if .Values.extraEnvVars }}
           {{- toYaml .Values.extraEnvVars | nindent 8 }}
@@ -79,4 +82,7 @@ spec:
       - name: data
         persistentVolumeClaim:
           claimName: {{ include "pipelines.name" . }}
+      {{- end }}
+      {{- with .Values.volumes }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/pipelines/values.yaml
+++ b/charts/pipelines/values.yaml
@@ -88,6 +88,24 @@ extraEnvVars:
   # - name: LANGFUSE_HOST
   #   value: https://us.cloud.langfuse.com
 
+# -- Configure container volume mounts
+# ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/>
+volumeMounts: []
+  # - name: ""
+  #   mountPath: ""
+
+# -- Configure pod volumes
+# ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/>
+volumes: []
+# - name: ""
+#   configMap:
+#     name: ""
+# - name: ""
+#   secret:
+#     name: ""
+# - name: ""
+#   emptyDir: {}
+
 # -- Extra resources to deploy with Open WebUI Pipelines
 extraResources:
   []


### PR DESCRIPTION
## Opinion
Hello, guys. I suggest applying values for `volumeMounts` and `volumes` in the pipelines chart.

- Adding this will allow us to include extra volumes from NFS storage, `Secrets`, `ConfigMaps`.
- To resolve #150
    - SSH Keys can be mounted as **secret volume** to the pipeline container

## Verification

run followings:
```sh
helm template pipelines ./charts/pipelines \
  --namespace test-namespace \
  --set "volumes[0].name=empty" \
  --set "volumes[0].emptyDir=null" \
  --set "volumeMounts[0].name=empty" \
  --set "volumeMounts[0].mountPath=/test-empty-volume" \
  > owui-pipelines-test.yaml

kubectl create ns test-namespace
kubectl apply -f owui-pipelines-issue-test.yaml
```

## PR

- I changed the chart and checked docs, values
- I skipped bumping chart version so I leave this PR as a draft 
    - After #171 (v0.5.13) merged and PR for v0.5.14, we could continue this PR
