### PR TITLE
feat(open-webui): enhance redis deployment with additional configurable properties

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 5.16.0
+version: 5.16.1
 appVersion: 0.5.14
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 5.16.0](https://img.shields.io/badge/Version-5.16.0-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
+![Version: 5.16.1](https://img.shields.io/badge/Version-5.16.1-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -109,7 +109,8 @@ helm upgrade --install open-webui open-webui/open-webui
 | volumes | list | `[]` | Configure pod volumes ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/> |
 | websocket.enabled | bool | `false` | Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT` |
 | websocket.manager | string | `"redis"` | Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default) |
-| websocket.redis | object | `{"annotations":{},"args":[],"command":[],"enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"redis","tag":"7.4.2-alpine3.21"},"labels":{},"name":"open-webui-redis","pods":{"annotations":{}},"resources":{},"service":{"annotations":{},"containerPort":6379,"labels":{},"nodePort":"","port":6379,"type":"ClusterIP"}}` | Deploys a redis |
+| websocket.redis | object | `{"affinity":{},"annotations":{},"args":[],"command":[],"enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"redis","tag":"7.4.2-alpine3.21"},"labels":{},"name":"open-webui-redis","pods":{"annotations":{}},"resources":{},"service":{"annotations":{},"containerPort":6379,"labels":{},"nodePort":"","port":6379,"type":"ClusterIP"},"tolerations":[]}` | Deploys a redis |
+| websocket.redis.affinity | object | `{}` | Redis affinity for pod assignment |
 | websocket.redis.annotations | object | `{}` | Redis annotations |
 | websocket.redis.args | list | `[]` | Redis arguments (overrides default) |
 | websocket.redis.command | list | `[]` | Redis command (overrides default) |
@@ -127,6 +128,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | websocket.redis.service.nodePort | string | `""` | Redis service node port. Valid only when type is `NodePort` |
 | websocket.redis.service.port | int | `6379` | Redis service port |
 | websocket.redis.service.type | string | `"ClusterIP"` | Redis service type |
+| websocket.redis.tolerations | list | `[]` | Redis tolerations for pod assignment |
 | websocket.url | string | `"redis://open-webui-redis:6379/0"` | Specifies the URL of the Redis instance for websocket communication. Template with `redis://[:<password>@]<hostname>:<port>/<db>` |
 
 ----------------------------------------------

--- a/charts/open-webui/templates/websocket-redis.yaml
+++ b/charts/open-webui/templates/websocket-redis.yaml
@@ -45,6 +45,14 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- with .Values.websocket.redis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.websocket.redis.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -84,6 +84,11 @@ websocket:
       port: 6379
       # -- Redis service node port. Valid only when type is `NodePort`
       nodePort: ""
+    # -- Redis tolerations for pod assignment
+    tolerations: []
+
+    # -- Redis affinity for pod assignment
+    affinity: {}
 
 # -- Deploys a Redis cluster with subchart 'redis' from bitnami
 redis-cluster:

--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -70,8 +70,8 @@ helm upgrade --install open-webui open-webui/pipelines
 | serviceAccount.automountServiceAccountToken | bool | `false` |  |
 | serviceAccount.enable | bool | `true` |  |
 | tolerations | list | `[]` | Tolerations for pod assignment |
-| volumeMounts | list | `[]` | Configure container volume mounts |
-| volumes | list | `[]` | Configure pod volumes |
+| volumeMounts | list | `[]` | Configure container volume mounts ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/> |
+| volumes | list | `[]` | Configure pod volumes ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/> |
 
 ----------------------------------------------
 


### PR DESCRIPTION
## Title

This PR introduces new enhancements to the Redis Deployment template within the Helm chart, enabling greater flexibility and configurability. 

## Changes

Adds support for the following properties:

- **affinity** : Adds the capability to set affinity rules, which can be used to influence the scheduling of Pods on nodes based on certain criteria.
- **tolerations** : Enables setting tolerations, allowing Pods to be scheduled on nodes with matching taints.

These additions are optional and can be specified in the Helm chart values under affinity, and tolerations. This enhancement aims to provide users with more configurability and control over how their Kubernetes Jobs are executed in diverse environments.
