### PR TITLE
feat(open-webui): add `envFrom` value

### DIFF
--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -47,6 +47,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | clusterDomain | string | `"cluster.local"` | Value of cluster domain |
 | containerSecurityContext | object | `{}` | Configure container security context ref: <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-containe> |
 | copyAppData.resources | object | `{}` |  |
+| envFrom | list | `[]` | Env vars added to the Open WebUI deployment from an external resource (e.g.: secret, configmap). Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/ |
 | extraEnvVars | list | `[{"name":"OPENAI_API_KEY","value":"0p3n-w3bu!"}]` | Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/ |
 | extraEnvVars[0] | object | `{"name":"OPENAI_API_KEY","value":"0p3n-w3bu!"}` | Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines |
 | extraResources | list | `[]` | Extra resources to deploy with Open WebUI |

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -112,6 +112,9 @@ spec:
         {{- with .Values.volumeMounts.container }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with .Values.envFrom }}
+        envFrom: {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         {{- if .Values.ollamaUrlsFromExtraEnv}}
         {{- else if or .Values.ollamaUrls .Values.ollama.enabled }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -237,6 +237,12 @@ openaiBaseApiUrls: []
   # - "https://api.openai.com/v1"
   # - "https://api.company.openai.com/v1"
 
+# -- Env vars added from secrets or configmaps
+envFrom:
+  []
+  # - secretRef:
+  #     name: open-web-ui
+
 # -- Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/
 extraEnvVars:
   # -- Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -237,7 +237,9 @@ openaiBaseApiUrls: []
   # - "https://api.openai.com/v1"
   # - "https://api.company.openai.com/v1"
 
-# -- Env vars added from secrets or configmaps
+# -- Env vars added to the Open WebUI deployment from an external resource
+# (e.g.: secret, configmap). Most up-to-date environment variables can be found
+# here: https://docs.openwebui.com/getting-started/env-configuration/
 envFrom:
   []
   # - secretRef:


### PR DESCRIPTION
to allow injecting environment variables from secrets or configmaps.

It is useful to be able to provide environment variables to Open WebUI that come from secrets or configmaps.

E.g.:

```yaml
envFrom:
  - secretRef:
      name: open-web-ui
```

In my case,  I want to use a secret like this to inject a value for `OAUTH_CLIENT_SECRET`.