### PR TITLE
Update open-webui to v0.5.15 (chart 5.17.0)

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 5.16.1
-appVersion: 0.5.14
+version: 5.17.0
+appVersion: 0.5.15
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 5.16.1](https://img.shields.io/badge/Version-5.16.1-informational?style=flat-square) ![AppVersion: 0.5.14](https://img.shields.io/badge/AppVersion-0.5.14-informational?style=flat-square)
+![Version: 5.17.0](https://img.shields.io/badge/Version-5.17.0-informational?style=flat-square) ![AppVersion: 0.5.15](https://img.shields.io/badge/AppVersion-0.5.15-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
Hello, guys

- By https://github.com/open-webui/open-webui/releases/tag/v0.5.15, we need to bump the open-webui chart

## PR

**chore: update open-webui to v0.5.15 (chart 5.17.0)**
- update open-webui
    - app: from v0.5.14 to v0.5.15
    - chart: from 5.16.1 to 5.17.0
- no dependency update