### PR TITLE
feat: [pipelines] add strategy

### DIFF
--- a/charts/pipelines/Chart.yaml
+++ b/charts/pipelines/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pipelines
-version: 0.2.0
+version: 0.3.0
 appVersion: "alpha"
 
 home: https://github.com/open-webui/pipelines

--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -69,6 +69,7 @@ helm upgrade --install open-webui open-webui/pipelines
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.automountServiceAccountToken | bool | `false` |  |
 | serviceAccount.enable | bool | `true` |  |
+| strategy | object | `{}` | Strategy for updating the deployment |
 | tolerations | list | `[]` | Tolerations for pod assignment |
 | volumeMounts | list | `[]` | Configure container volume mounts ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/> |
 | volumes | list | `[]` | Configure pod volumes ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/> |

--- a/charts/pipelines/templates/deployment.yaml
+++ b/charts/pipelines/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
   selector:
     matchLabels:
       {{- include "pipelines.selectorLabels" . | nindent 6 }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/pipelines/values.yaml
+++ b/charts/pipelines/values.yaml
@@ -8,6 +8,8 @@ annotations: {}
 podAnnotations: {}
 podLabels: {}
 replicaCount: 1
+# -- Strategy for updating the deployment
+strategy: {}
 image:
   repository: ghcr.io/open-webui/pipelines
   tag: main


### PR DESCRIPTION
Hello, guys. I suggest a new feature for the pipelines chart. Any question and contribution are welcome 🤗

## PR
- To resolve #179
    - [x] Make changes / Test changes / Run helm-docs
- **feat(pipelines): add `strategy` for updating deployment**
    - bump the pipelines chart from 0.2.0 to 0.3.0

## Verification

```sh
helm template pipelines ./charts/pipelines \
  --namespace test-namespace \
  --set "strategy.type=RollingUpdate" \
  --set "strategy.rollingUpdate.maxSurge=0" \
  --set "strategy.rollingUpdate.maxUnavailable=1" \
> owui-pipelines-test.yaml

kubectl create ns test-namespace
kubectl apply -f owui-pipelines-test.yaml

kubectl describe -n test-namespace deploy pipelines | grep "RollingUpdateStrategy"
# result -> "RollingUpdateStrategy:  1 max unavailable, 0 max surge"
```

**Run Command**
![image](https://github.com/user-attachments/assets/67d8b40b-7135-4d0f-a252-741e8c44d695)

**Deployment Description (YAML)**
![image](https://github.com/user-attachments/assets/b63ec93c-4069-461f-8d84-6439a3c44e88)

