### PR TITLE
fix(ci/release): Fix helm dependency for milvus

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -65,6 +65,7 @@ jobs:
           helm repo add open-webui https://helm.openwebui.com/
           helm repo add tika https://apache.jfrog.io/artifactory/tika/
           helm repo add redis https://charts.bitnami.com/bitnami
+          helm repo add milvus https://zilliztech.github.io/milvus-helm
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0


### PR DESCRIPTION
## PR
- To resolve #195
- I forgot add milvus repository for [the release workflow](https://github.com/open-webui/helm-charts/actions/runs/13755276088)
- Fix release workflow for **`open-webui-5.21.0`**

Please check it!