### PR TITLE
fix: redis pod annotation nindent 4 to 8

### DIFF
--- a/charts/open-webui/templates/websocket-redis.yaml
+++ b/charts/open-webui/templates/websocket-redis.yaml
@@ -23,7 +23,7 @@ spec:
         {{- include "websocket.redis.labels" . | nindent 8 }}
       annotations:
         {{- with .Values.websocket.redis.pods.annotations }}
-        {{- toYaml . | nindent 4 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.websocket.redis.image.pullSecretName }}


### PR DESCRIPTION
I made a mistake when opening the first PR including `websocket.redis.pods.annotations`.

The correct nindent is 8 and I sent 4.

**Before this PR:**
![Screenshot 2025-03-19 at 08 38 27](https://github.com/user-attachments/assets/47aeb0af-988a-4d53-99f1-b58dac93235c)

**After this PR:**
![Screenshot 2025-03-19 at 08 35 59](https://github.com/user-attachments/assets/10fcd88d-5031-4d09-b971-1483b0b5e072)
![Screenshot 2025-03-19 at 08 37 31](https://github.com/user-attachments/assets/177555e2-ef16-4cb5-9db4-bdde683af85d)
