### PR TITLE
feat: Added runtimeClassName to open-webui deployment.

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 5.25.0
+version: 5.26.0
 appVersion: 0.5.20
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 5.24.0](https://img.shields.io/badge/Version-5.24.0-informational?style=flat-square) ![AppVersion: 0.5.20](https://img.shields.io/badge/AppVersion-0.5.20-informational?style=flat-square)
+![Version: 5.26.0](https://img.shields.io/badge/Version-5.26.0-informational?style=flat-square) ![AppVersion: 0.5.20](https://img.shields.io/badge/AppVersion-0.5.20-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -98,6 +98,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | redis-cluster.replica.replicaCount | int | `3` | Number of Redis replica instances |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| runtimeClassName | string | `""` | Allows changing the Runtime Class. For ex. to "nvidia" if nvidia container runtime is installed but not default. |
 | service | object | `{"annotations":{},"containerPort":8080,"labels":{},"loadBalancerClass":"","nodePort":"","port":80,"type":"ClusterIP"}` | Service values to expose Open WebUI pods to cluster |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.automountServiceAccountToken | bool | `false` |  |

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -74,6 +74,9 @@ spec:
       {{- end }}
       enableServiceLinks: false
       automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
+      {{- if .Values.runtimeClassName }}
+      runtimeClassName: {{ .Values.runtimeClassName | quote }}
+      {{- end }}
       {{- if .Values.serviceAccount.enable }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "open-webui.name" .) }}
       {{- end }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -266,6 +266,10 @@ extraEnvVars:
   # - name: OLLAMA_DEBUG
   #   value: "1"
 
+# -- Configure runtime class
+# ref: <https://kubernetes.io/docs/concepts/containers/runtime-class/>
+runtimeClassName: ""
+
 # -- Configure container volume mounts
 # ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/>
 volumeMounts:


### PR DESCRIPTION
Gets inline with ollama deployment allowing open-webui deployment to define a runtimeClassName.

Its required if your clusters/node default runtime is different than the one required for nvidia container runtime for. ex. Requires you to set runtimeClassName to "nvidia".

This opens the possiblity to use "-cuda" image with "USE_CUDA_DOCKER=true" allowing Whipser using CUDA.

Merge after: https://github.com/open-webui/helm-charts/pull/208 (because of version number)