### PR TITLE
Update ollama chart to 1.11.0(ollama 0.6.2)

### DIFF
--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: ollama
   repository: https://otwld.github.io/ollama-helm/
-  version: 1.9.0
+  version: 1.11.0
 - name: pipelines
   repository: https://helm.openwebui.com
   version: 0.5.0
@@ -10,6 +10,6 @@ dependencies:
   version: 2.9.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 20.11.3
-digest: sha256:8883c56753b4403161c144cdc5cb1ef3871c75cc511120709c4a848929126200
-generated: "2025-03-13T21:36:36.180953+09:00"
+  version: 20.11.4
+digest: sha256:f118370f7f773e7ba4a6bf1a3ed0b763afa38ca265e7d9b3981877cc4b812cd2
+generated: "2025-03-28T07:49:19.357081Z"


### PR DESCRIPTION
To add support gemma3 properly, please update ollama.