### PR TITLE
feat(open-webui): Make it possible to define SSO OAuth secrets from Kubernetes Secrets

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 6.6.0
+version: 6.7.0
 appVersion: 0.6.6
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.6.0](https://img.shields.io/badge/Version-6.6.0-informational?style=flat-square) ![AppVersion: 0.6.6](https://img.shields.io/badge/AppVersion-0.6.6-informational?style=flat-square)
+![Version: 6.7.0](https://img.shields.io/badge/Version-6.7.0-informational?style=flat-square) ![AppVersion: 0.6.6](https://img.shields.io/badge/AppVersion-0.6.6-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -57,24 +57,30 @@ helm upgrade --install open-webui open-webui/open-webui
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| sso.github.clientExistingSecret | string | `""` | GitHub OAuth client secret from existing secret |
+| sso.github.clientExistingSecretKey | string | `""` | GitHub OAuth client secret key from existing secret |
 | sso.github.clientId | string | `""` | GitHub OAuth client ID |
-| sso.github.clientSecret | string | `""` | GitHub OAuth client secret |
+| sso.github.clientSecret | string | `""` | GitHub OAuth client secret (ignored if clientExistingSecret is set) |
 | sso.github.enabled | bool | `false` | Enable GitHub OAuth |
 
 ### Google OAuth configuration
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| sso.google.clientExistingSecret | string | `""` | Google OAuth client secret from existing secret |
+| sso.google.clientExistingSecretKey | string | `""` | Google OAuth client secret key from existing secret |
 | sso.google.clientId | string | `""` | Google OAuth client ID |
-| sso.google.clientSecret | string | `""` | Google OAuth client secret |
+| sso.google.clientSecret | string | `""` | Google OAuth client secret (ignored if clientExistingSecret is set) |
 | sso.google.enabled | bool | `false` | Enable Google OAuth |
 
 ### Microsoft OAuth configuration
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| sso.microsoft.clientExistingSecret | string | `""` | Microsoft OAuth client secret from existing secret |
+| sso.microsoft.clientExistingSecretKey | string | `""` | Microsoft OAuth client secret key from existing secret |
 | sso.microsoft.clientId | string | `""` | Microsoft OAuth client ID |
-| sso.microsoft.clientSecret | string | `""` | Microsoft OAuth client secret |
+| sso.microsoft.clientSecret | string | `""` | Microsoft OAuth client secret (ignored if clientExistingSecret is set) |
 | sso.microsoft.enabled | bool | `false` | Enable Microsoft OAuth |
 | sso.microsoft.tenantId | string | `""` | Microsoft tenant ID - use 9188040d-6c67-4c5b-b112-36a304b66dad for personal accounts |
 
@@ -82,8 +88,10 @@ helm upgrade --install open-webui open-webui/open-webui
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| sso.oidc.clientExistingSecret | string | `""` | OICD client secret from existing secret |
+| sso.oidc.clientExistingSecretKey | string | `""` | OIDC client secret key from existing secret |
 | sso.oidc.clientId | string | `""` | OIDC client ID |
-| sso.oidc.clientSecret | string | `""` | OIDC client secret |
+| sso.oidc.clientSecret | string | `""` | OIDC client secret (ignored if clientExistingSecret is set) |
 | sso.oidc.enabled | bool | `false` | Enable OIDC authentication |
 | sso.oidc.providerName | string | `"SSO"` | Name of the provider to show on the UI |
 | sso.oidc.providerUrl | string | `""` | OIDC provider well known URL |

--- a/charts/open-webui/templates/_helpers.tpl
+++ b/charts/open-webui/templates/_helpers.tpl
@@ -169,3 +169,14 @@ Create labels to include on chart all websocket resources
 {{ include "base.labels" . }}
 {{ include "websocket.redis.selectorLabels" . }}
 {{- end }}
+
+{{/*
+Validate SSO ClientSecret to be set literally or via Secret
+*/}}
+{{- define "sso.validateClientSecret" -}}
+{{- $provider := .provider }}
+{{- $values := .values }}
+{{- if and (empty (index $values $provider "clientSecret")) (empty (index $values $provider "clientExistingSecret")) }}
+  {{- fail (printf "You must provide either .Values.sso.%s.clientSecret or .Values.sso.%s.clientExistingSecret" $provider $provider) }}
+{{- end }}
+{{- end }}

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -209,28 +209,60 @@ spec:
         {{- if .Values.sso.google.enabled }}
         - name: "GOOGLE_CLIENT_ID"
           value: {{ .Values.sso.google.clientId | quote }}
+        {{- include "sso.validateClientSecret" (dict "provider" "google" "values" .Values.sso) }}
         - name: "GOOGLE_CLIENT_SECRET"
+        {{- if .Values.sso.google.clientExistingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sso.google.clientExistingSecret | quote }}
+              key: {{ .Values.sso.google.clientExistingSecretKey | quote }}
+        {{- else }}
           value: {{ .Values.sso.google.clientSecret | quote }}
+        {{- end }}
         {{- end }}
         {{- if .Values.sso.microsoft.enabled }}
         - name: "MICROSOFT_CLIENT_ID"
           value: {{ .Values.sso.microsoft.clientId | quote }}
+        {{- include "sso.validateClientSecret" (dict "provider" "microsoft" "values" .Values.sso) }}
         - name: "MICROSOFT_CLIENT_SECRET"
+        {{- if .Values.sso.microsoft.clientExistingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sso.microsoft.clientExistingSecret | quote }}
+              key: {{ .Values.sso.microsoft.clientExistingSecretKey | quote }}
+        {{- else }}
           value: {{ .Values.sso.microsoft.clientSecret | quote }}
+        {{- end }}
         - name: "MICROSOFT_CLIENT_TENANT_ID"
           value: {{ .Values.sso.microsoft.tenantId | quote }}
         {{- end }}
         {{- if .Values.sso.github.enabled }}
         - name: "GITHUB_CLIENT_ID"
           value: {{ .Values.sso.github.clientId | quote }}
+        {{- include "sso.validateClientSecret" (dict "provider" "github" "values" .Values.sso) }}
         - name: "GITHUB_CLIENT_SECRET"
+        {{- if .Values.sso.github.clientExistingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sso.github.clientExistingSecret | quote }}
+              key: {{ .Values.sso.github.clientExistingSecretKey | quote }}
+        {{- else }}
           value: {{ .Values.sso.github.clientSecret | quote }}
+        {{- end }}
         {{- end }}
         {{- if .Values.sso.oidc.enabled }}
         - name: "OAUTH_CLIENT_ID"
           value: {{ .Values.sso.oidc.clientId | quote }}
+        {{- include "sso.validateClientSecret" (dict "provider" "oidc" "values" .Values.sso) }}
         - name: "OAUTH_CLIENT_SECRET"
+        {{- if .Values.sso.oidc.clientExistingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.sso.oidc.clientExistingSecret | quote }}
+              key: {{ .Values.sso.oidc.clientExistingSecretKey | quote }}
+        {{- else }}
           value: {{ .Values.sso.oidc.clientSecret | quote }}
+        {{- end }}
         - name: "OPENID_PROVIDER_URL"
           value: {{ .Values.sso.oidc.providerUrl | quote }}
         - name: "OAUTH_PROVIDER_NAME"

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -415,9 +415,15 @@ sso:
     # -- Google OAuth client ID
     # @section -- Google OAuth configuration
     clientId: ""
-    # -- Google OAuth client secret
+    # -- Google OAuth client secret (ignored if clientExistingSecret is set)
     # @section -- Google OAuth configuration
     clientSecret: ""
+    # -- Google OAuth client secret from existing secret
+    # @section -- Google OAuth configuration
+    clientExistingSecret: ""
+    # -- Google OAuth client secret key from existing secret
+    # @section -- Google OAuth configuration
+    clientExistingSecretKey: ""
 
   microsoft:
     # -- Enable Microsoft OAuth
@@ -426,9 +432,15 @@ sso:
     # -- Microsoft OAuth client ID
     # @section -- Microsoft OAuth configuration
     clientId: ""
-    # -- Microsoft OAuth client secret
+    # -- Microsoft OAuth client secret (ignored if clientExistingSecret is set)
     # @section -- Microsoft OAuth configuration
     clientSecret: ""
+    # -- Microsoft OAuth client secret from existing secret
+    # @section -- Microsoft OAuth configuration
+    clientExistingSecret: ""
+    # -- Microsoft OAuth client secret key from existing secret
+    # @section -- Microsoft OAuth configuration
+    clientExistingSecretKey: ""
     # -- Microsoft tenant ID - use 9188040d-6c67-4c5b-b112-36a304b66dad for personal accounts
     # @section -- Microsoft OAuth configuration
     tenantId: ""
@@ -440,9 +452,15 @@ sso:
     # -- GitHub OAuth client ID
     # @section -- GitHub OAuth configuration
     clientId: ""
-    # -- GitHub OAuth client secret
+    # -- GitHub OAuth client secret (ignored if clientExistingSecret is set)
     # @section -- GitHub OAuth configuration
     clientSecret: ""
+    # -- GitHub OAuth client secret from existing secret
+    # @section -- GitHub OAuth configuration
+    clientExistingSecret: ""
+    # -- GitHub OAuth client secret key from existing secret
+    # @section -- GitHub OAuth configuration
+    clientExistingSecretKey: ""
 
   oidc:
     # -- Enable OIDC authentication
@@ -451,9 +469,15 @@ sso:
     # -- OIDC client ID
     # @section -- OIDC configuration
     clientId: ""
-    # -- OIDC client secret
+    # -- OIDC client secret (ignored if clientExistingSecret is set)
     # @section -- OIDC configuration
     clientSecret: ""
+    # -- OICD client secret from existing secret
+    # @section -- OIDC configuration
+    clientExistingSecret: ""
+    # -- OIDC client secret key from existing secret
+    # @section -- OIDC configuration
+    clientExistingSecretKey: ""
     # -- OIDC provider well known URL
     # @section -- OIDC configuration
     providerUrl: ""


### PR DESCRIPTION
Hi,

This PR extends the Open WebUI Helm chart to allow the SSO ClientSecret to be defined either directly in the `values.yaml` file or via a Kubernetes Secret for all supported providers.

Additionally, I’ve added validation logic in the helpers to ensure that when an SSO provider is enabled, either the `clientSecret` or the `clientExistingSecret` variable must be provided. If both are defined, the `clientSecret` will be ignored in favor of the `clientExistingSecret`.

The changes were tested locally using helm template, and the rendering works as expected.

For a  given secret for Microsoft SSO,

```console
kubectl create secret generic test --from-literal=mykey=REDACTED
```

`values-test.yaml` is,

```yaml
# Disable bundled dependencies
ollama:
  enabled: false

pipelines:
  # -- Automatically install Pipelines chart to extend Open WebUI functionality using Pipelines: https://github.com/open-webui/pipelines
  enabled: false
  # -- This section can be used to pass required environment variables to your pipelines (e.g. Langfuse hostname)
  extraEnvVars: []

tika:
  # -- Automatically install Apache Tika to extend Open WebUI
  enabled: false

# -- A list of Ollama API endpoints. These can be added in lieu of automatically installing the Ollama Helm chart, or in addition to it.
ollamaUrls: []

# -- Disables taking Ollama Urls from `ollamaUrls`  list
ollamaUrlsFromExtraEnv: false

websocket:
  # -- Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT`
  enabled: true
  # -- Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default)
  manager: redis
  # -- Deploys a redis
  redis:
    # -- Enable redis installation
    enabled: false

# -- Deploys a Redis cluster with subchart 'redis' from bitnami
redis-cluster:
  # -- Enable Redis installation
  enabled: true
  # -- Redis cluster name (recommended to be 'open-webui-redis')
  # - In this case, redis url will be 'redis://open-webui-redis-master:6379/0' or 'redis://[:<password>@]open-webui-redis-master:6379/0'
  fullnameOverride: open-webui-redis
  # -- Redis Authentication
  auth:
    # -- Enable Redis authentication (disabled by default). For your security, we strongly suggest that you switch to 'auth.enabled=true'
    enabled: false
  # -- Replica configuration for the Redis cluster
  replica:
    # -- Number of Redis replica instances
    replicaCount: 3


replicaCount: 2

serviceAccount:
  enable: true

ingress:
  enabled: true
  class: "external"
  # -- Use appropriate annotations for your Ingress controller, e.g., for NGINX:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt
    nginx.ingress.kubernetes.io/affinity: "cookie"
    nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
    nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
    nginx.ingress.kubernetes.io/session-cookie-name: "route"
  host: "REDACTED"
  tls: true

persistence:
  enabled: true
  # -- Sets the storage provider, availables values are `local`, `s3`, `gcs` or `azure`
  provider: azure
  azure:
    # -- Sets the endpoint URL for Azure Storage
    endpointUrl: "REDACTED"
    # -- Sets the container name for Azure Storage
    container: "data"
    key: "test"

# -- Enables the use of OpenAI APIs
enableOpenaiApi: true

# -- OpenAI base API URL to use. Defaults to the Pipelines service endpoint when Pipelines are enabled, and "https://api.openai.com/v1" if Pipelines are not enabled and this value is blank
openaiBaseApiUrl: "https://api.openai.com/v1"

# -- Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/
extraEnvVars:
  # -- Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines
  # OpenAI config
  - name: OPENAI_API_KEY
    valueFrom:
      secretKeyRef:
        name: openai-api-key
        key: api-key
  - name: ENABLE_MODEL_FILTER
    value: "true"
  - name: MODEL_FILTER_LIST
    value: "gpt-4o-mini;gpt-4o-2024-08-06;ask_hr_policies"
  - name: DEFAULT_MODELS
    value: "gpt-4o-mini"
  - name: DEFAULT_LOCALE
    value: "en_US"
  - name: DEFAULT_USER_ROLE
    value: "user"
  # Blob storage key
  - name: AZURE_STORAGE_KEY
    valueFrom:
      secretKeyRef:
        name: azure-storage-account
        key: azure-account-key
  # Database URL
  - name: DATABASE_URL
    valueFrom:
      secretKeyRef:
        name: postgres-db-url
        key: postgres-url
  # Redis
  - name: WEBSOCKET_REDIS_URL
    value: "redis://infra-openwebui-redis.infra-openwebui.svc.cluster.local:26379/0"
  - name: WEBSOCKET_REDIS_MASTER_NAME
    value: "mymaster"
  - name: WEBSOCKET_REDIS_PASSWORD
    valueFrom:
      secretKeyRef:
        name: redis
        key: secret
  # Log Level
  - name: GLOBAL_LOG_LEVEL
    value: "debug"

sso:
  # -- **Enable SSO authentication globally** must enable to use SSO authentication
  # @section -- SSO Configuration
  enabled: true
  # -- Enable account creation when logging in with OAuth (distinct from regular signup)
  # @section -- SSO Configuration
  enableSignup: false
  # -- Allow logging into accounts that match email from OAuth provider (considered insecure)
  # @section -- SSO Configuration
  mergeAccountsByEmail: false
  # -- Enable OAuth role management through access token roles claim
  # @section -- SSO Configuration
  enableRoleManagement: false
  # -- Enable OAuth group management through access token groups claim
  # @section -- SSO Configuration
  enableGroupManagement: false

  microsoft:
    # -- Enable Microsoft OAuth
    enabled: true
    # -- Microsoft OAuth client ID
    clientId: "REDACTED"
    # -- Microsoft tenant ID - use 9188040d-6c67-4c5b-b112-36a304b66dad for personal accounts
    tenantId: "REDACTED"
    clientSecret: "test"
    clientExistingSecret: "test"
    clientExistingSecretKey: "mykey"

  roleManagement:
    # -- The claim that contains the roles (can be nested, e.g., user.roles)
    # @section -- Role management configuration
    rolesClaim: "roles"
    # -- Comma-separated list of roles allowed to log in (receive open webui role user)
    # @section -- Role management configuration
    allowedRoles: ""
    # -- Comma-separated list of roles allowed to log in as admin (receive open webui role admin)
    # @section -- Role management configuration
    adminRoles: ""

  groupManagement:
    # -- The claim that contains the groups (can be nested, e.g., user.memberOf)
    # @section -- SSO Configuration
    groupsClaim: "groups"

  trustedHeader:
    # -- Enable trusted header authentication
    # @section -- SSO trusted header authentication
    enabled: false
    # -- Header containing the user's email address
    # @section -- SSO trusted header authentication
    emailHeader: ""
    # -- Header containing the user's name (optional, used for new user creation)
    # @section -- SSO trusted header authentication
    nameHeader: ""

# -- Postgresql configuration (see. https://artifacthub.io/packages/helm/bitnami/postgresql)
postgresql:
  enabled: false
```

And rendering with helm template,

```console
helm template . --values values-test.yaml > redacted-secrets.yaml
```

Now with default empty values for clientExistingSecret and clientExistingSecretKey,

```yaml
  microsoft:
    # -- Enable Microsoft OAuth
    enabled: true
    # -- Microsoft OAuth client ID
    clientId: "REDACTED"
    # -- Microsoft tenant ID - use 9188040d-6c67-4c5b-b112-36a304b66dad for personal accounts
    tenantId: "REDACTED"
    clientSecret: "test"
    clientExistingSecret: ""
    clientExistingSecretKey: ""
```

```console
helm template . --values values-test.yaml > redacted-raw.yaml
```

The difference between the two cases is,

```bash
diff -u redacted-secrets.yaml redacted-raw.yaml
--- redacted-secrets.yaml       2025-05-06 08:25:24
+++ redacted-raw.yaml   2025-05-06 08:26:04
@@ -509,10 +509,7 @@
         - name: "MICROSOFT_CLIENT_ID"
           value: "REDACTED"
         - name: "MICROSOFT_CLIENT_SECRET"
-          valueFrom:
-            secretKeyRef:
-              name: "test"
-              key: "mykey"
+          value: "test"
         - name: "MICROSOFT_CLIENT_TENANT_ID"
           value: "REDACTED"
         - name: OPENAI_API_KEY
```

and this repeats for every provider.

Please let me know if you approve of this extension. I’m happy to contribute further to this project!

Thank you!