### PR TITLE
feat(open-webui): Make it possible to configure Storage credentials via k8s secrets

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 6.8.0
+version: 6.9.0
 appVersion: 0.6.6
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -51,6 +51,15 @@ helm upgrade --install open-webui open-webui/open-webui
 | persistence.azure.keyExistingSecret | string | `""` | Set the access key for Azure Storage from existing secret |
 | persistence.azure.keyExistingSecretKey | string | `""` | Set the access key for Azure Storage from existing secret key |
 
+### Google Cloud Storage configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| persistence.gcs.appCredentialsJson | string | `""` | Contents of Google Application Credentials JSON file (ignored if appCredentialsJsonExistingSecret is set). Optional - if not provided, credentials will be taken from the environment. User credentials if run locally and Google Metadata server if run on a Google Compute Engine. File can be generated for a service account following this guide: https://developers.google.com/workspace/guides/create-credentials#service-account |
+| persistence.gcs.appCredentialsJsonExistingSecret | string | `""` | Set the Google Application Credentials JSON file for Google Cloud Storage from existing secret |
+| persistence.gcs.appCredentialsJsonExistingSecretKey | string | `""` | Set the Google Application Credentials JSON file for Google Cloud Storage from existing secret key |
+| persistence.gcs.bucket | string | `""` | Sets the bucket name for Google Cloud Storage. Bucket must already exist |
+
 ### SSO Configuration
 
 | Key | Type | Default | Description |
@@ -165,8 +174,6 @@ helm upgrade --install open-webui open-webui/open-webui
 | persistence.annotations | object | `{}` |  |
 | persistence.enabled | bool | `true` |  |
 | persistence.existingClaim | string | `""` | Use existingClaim if you want to re-use an existing Open WebUI PVC instead of creating a new one |
-| persistence.gcs.appCredentialsJson | string | `""` | Contents of Google Application Credentials JSON file. Optional - if not provided, credentials will be taken from the environment. User credentials if run locally and Google Metadata server if run on a Google Compute Engine. File can be generated for a service account following this guide: https://developers.google.com/workspace/guides/create-credentials#service-account |
-| persistence.gcs.bucket | string | `""` | Sets the bucket name for Google Cloud Storage. Bucket must already exist |
 | persistence.provider | string | `"local"` | Sets the storage provider, availables values are `local`, `s3`, `gcs` or `azure` |
 | persistence.s3.accessKey | string | `""` | Sets the access key ID for S3 storage |
 | persistence.s3.bucket | string | `""` | Sets the bucket name for S3 storage |

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -41,6 +41,16 @@ helm upgrade --install open-webui open-webui/open-webui
 
 ## Values
 
+### Azure Storage configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| persistence.azure.container | string | `""` | Sets the container name for Azure Storage |
+| persistence.azure.endpointUrl | string | `""` | Sets the endpoint URL for Azure Storage |
+| persistence.azure.key | string | `""` | Set the access key for Azure Storage (ignored if keyExistingSecret is set). Optional - if not provided, credentials will be taken from the environment. User credentials if run locally and Managed Identity if run in Azure services |
+| persistence.azure.keyExistingSecret | string | `""` | Set the access key for Azure Storage from existing secret |
+| persistence.azure.keyExistingSecretKey | string | `""` | Set the access key for Azure Storage from existing secret key |
+
 ### SSO Configuration
 
 | Key | Type | Default | Description |
@@ -153,9 +163,6 @@ helm upgrade --install open-webui open-webui/open-webui
 | openaiBaseApiUrls | list | `[]` | OpenAI base API URLs to use. Overwrites the value in openaiBaseApiUrl if set |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | If using multiple replicas, you must update accessModes to ReadWriteMany |
 | persistence.annotations | object | `{}` |  |
-| persistence.azure.container | string | `""` | Sets the container name for Azure Storage |
-| persistence.azure.endpointUrl | string | `""` | Sets the endpoint URL for Azure Storage |
-| persistence.azure.key | string | `""` | Set the access key for Azure Storage. Optional - if not provided, credentials will be taken from the environment. User credentials if run locally and Managed Identity if run in Azure services |
 | persistence.enabled | bool | `true` |  |
 | persistence.existingClaim | string | `""` | Use existingClaim if you want to re-use an existing Open WebUI PVC instead of creating a new one |
 | persistence.gcs.appCredentialsJson | string | `""` | Contents of Google Application Credentials JSON file. Optional - if not provided, credentials will be taken from the environment. User credentials if run locally and Google Metadata server if run on a Google Compute Engine. File can be generated for a service account following this guide: https://developers.google.com/workspace/guides/create-credentials#service-account |

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.8.0](https://img.shields.io/badge/Version-6.8.0-informational?style=flat-square) ![AppVersion: 0.6.6](https://img.shields.io/badge/AppVersion-0.6.6-informational?style=flat-square)
+![Version: 6.9.0](https://img.shields.io/badge/Version-6.9.0-informational?style=flat-square) ![AppVersion: 0.6.6](https://img.shields.io/badge/AppVersion-0.6.6-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -59,6 +59,19 @@ helm upgrade --install open-webui open-webui/open-webui
 | persistence.gcs.appCredentialsJsonExistingSecret | string | `""` | Set the Google Application Credentials JSON file for Google Cloud Storage from existing secret |
 | persistence.gcs.appCredentialsJsonExistingSecretKey | string | `""` | Set the Google Application Credentials JSON file for Google Cloud Storage from existing secret key |
 | persistence.gcs.bucket | string | `""` | Sets the bucket name for Google Cloud Storage. Bucket must already exist |
+
+### Amazon S3 Storage configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| persistence.s3.accessKey | string | `""` | Sets the access key ID for S3 storage |
+| persistence.s3.bucket | string | `""` | Sets the bucket name for S3 storage |
+| persistence.s3.endpointUrl | string | `""` | Sets the endpoint url for S3 storage |
+| persistence.s3.keyPrefix | string | `""` | Sets the key prefix for a S3 object |
+| persistence.s3.region | string | `""` | Sets the region name for S3 storage |
+| persistence.s3.secretKey | string | `""` | Sets the secret access key for S3 storage (ignored if secretKeyExistingSecret is set) |
+| persistence.s3.secretKeyExistingSecret | string | `""` | Set the secret access key for S3 storage from existing k8s secret |
+| persistence.s3.secretKeyExistingSecretKey | string | `""` | Set the secret access key for S3 storage from existing k8s secret key |
 
 ### SSO Configuration
 
@@ -175,12 +188,6 @@ helm upgrade --install open-webui open-webui/open-webui
 | persistence.enabled | bool | `true` |  |
 | persistence.existingClaim | string | `""` | Use existingClaim if you want to re-use an existing Open WebUI PVC instead of creating a new one |
 | persistence.provider | string | `"local"` | Sets the storage provider, availables values are `local`, `s3`, `gcs` or `azure` |
-| persistence.s3.accessKey | string | `""` | Sets the access key ID for S3 storage |
-| persistence.s3.bucket | string | `""` | Sets the bucket name for S3 storage |
-| persistence.s3.endpointUrl | string | `""` | Sets the endpoint url for S3 storage |
-| persistence.s3.keyPrefix | string | `""` | Sets the key prefix for a S3 object |
-| persistence.s3.region | string | `""` | Sets the region name for S3 storage |
-| persistence.s3.secretKey | string | `""` | Sets the secret access key for S3 storage |
 | persistence.selector | object | `{}` |  |
 | persistence.size | string | `"2Gi"` |  |
 | persistence.storageClass | string | `""` |  |

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -183,7 +183,14 @@ spec:
         - name: "AZURE_STORAGE_CONTAINER_NAME"
           value: {{ .Values.persistence.azure.container }}
         - name: "AZURE_STORAGE_KEY"
+        {{- if .Values.persistence.azure.keyExistingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.persistence.azure.keyExistingSecret }}
+              key: {{ .Values.persistence.azure.keyExistingSecretKey }}
+        {{- else }}
           value: {{ .Values.persistence.azure.key }}
+        {{- end }}
         {{- end }}
         {{- if .Values.websocket.enabled }}
         - name: "ENABLE_WEBSOCKET_SUPPORT"

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -159,7 +159,14 @@ spec:
         - name: "S3_ACCESS_KEY_ID"
           value: {{ .Values.persistence.s3.accessKey }}
         - name: "S3_SECRET_ACCESS_KEY"
+        {{- if .Values.persistence.s3.secretKeyExistingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.persistence.s3.secretKeyExistingSecret }}
+              key: {{ .Values.persistence.s3.secretKeyExistingSecretKey }}
+        {{- else }}
           value: {{ .Values.persistence.s3.secretKey }}
+        {{- end }}
         - name: "S3_ENDPOINT_URL"
           value: {{ .Values.persistence.s3.endpointUrl }}
         - name: "S3_BUCKET_NAME"

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -172,7 +172,14 @@ spec:
         - name: "STORAGE_PROVIDER"
           value: {{ .Values.persistence.provider }}
         - name: "GOOGLE_APPLICATION_CREDENTIALS_JSON"
+        {{- if .Values.persistence.gcs.appCredentialsJsonExistingSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.persistence.gcs.appCredentialsJsonExistingSecret }}
+              key: {{ .Values.persistence.gcs.appCredentialsJsonExistingSecretKey }}
+        {{- else }}
           value: {{ .Values.persistence.gcs.appCredentialsJson }}
+        {{- end }}
         - name: "GCS_BUCKET_NAME"
           value: {{ .Values.persistence.gcs.bucket }}
         {{- else if eq .Values.persistence.provider "azure" }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -227,9 +227,17 @@ persistence:
     # -- Sets the key prefix for a S3 object
     keyPrefix: ""
   gcs:
-    # -- Contents of Google Application Credentials JSON file. Optional - if not provided, credentials will be taken from the environment. User credentials if run locally and Google Metadata server if run on a Google Compute Engine. File can be generated for a service account following this guide: https://developers.google.com/workspace/guides/create-credentials#service-account
+    # -- Contents of Google Application Credentials JSON file (ignored if appCredentialsJsonExistingSecret is set). Optional - if not provided, credentials will be taken from the environment. User credentials if run locally and Google Metadata server if run on a Google Compute Engine. File can be generated for a service account following this guide: https://developers.google.com/workspace/guides/create-credentials#service-account
+    # @section -- Google Cloud Storage configuration
     appCredentialsJson: ""
+    # -- Set the Google Application Credentials JSON file for Google Cloud Storage from existing secret
+    # @section -- Google Cloud Storage configuration
+    appCredentialsJsonExistingSecret: ""
+    # -- Set the Google Application Credentials JSON file for Google Cloud Storage from existing secret key
+    # @section -- Google Cloud Storage configuration
+    appCredentialsJsonExistingSecretKey: ""
     # -- Sets the bucket name for Google Cloud Storage. Bucket must already exist
+    # @section -- Google Cloud Storage configuration
     bucket: ""
   azure:
     # -- Sets the endpoint URL for Azure Storage

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -233,11 +233,20 @@ persistence:
     bucket: ""
   azure:
     # -- Sets the endpoint URL for Azure Storage
+    # @section -- Azure Storage configuration
     endpointUrl: ""
     # -- Sets the container name for Azure Storage
+    # @section -- Azure Storage configuration
     container: ""
-    # -- Set the access key for Azure Storage. Optional - if not provided, credentials will be taken from the environment. User credentials if run locally and Managed Identity if run in Azure services
+    # -- Set the access key for Azure Storage (ignored if keyExistingSecret is set). Optional - if not provided, credentials will be taken from the environment. User credentials if run locally and Managed Identity if run in Azure services
+    # @section -- Azure Storage configuration
     key: ""
+    # -- Set the access key for Azure Storage from existing secret
+    # @section -- Azure Storage configuration
+    keyExistingSecret: ""
+    # -- Set the access key for Azure Storage from existing secret key
+    # @section -- Azure Storage configuration
+    keyExistingSecretKey: ""
 
 # -- Node labels for pod assignment.
 nodeSelector: {}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -215,16 +215,28 @@ persistence:
   provider: local
   s3:
     # -- Sets the access key ID for S3 storage
+    # @section -- Amazon S3 Storage configuration
     accessKey: ""
-    # -- Sets the secret access key for S3 storage
+    # -- Sets the secret access key for S3 storage (ignored if secretKeyExistingSecret is set)
+    # @section -- Amazon S3 Storage configuration
     secretKey: ""
+    # -- Set the secret access key for S3 storage from existing k8s secret
+    # @section -- Amazon S3 Storage configuration
+    secretKeyExistingSecret: ""
+    # -- Set the secret access key for S3 storage from existing k8s secret key
+    # @section -- Amazon S3 Storage configuration
+    secretKeyExistingSecretKey: ""
     # -- Sets the endpoint url for S3 storage
+    # @section -- Amazon S3 Storage configuration
     endpointUrl: ""
     # -- Sets the region name for S3 storage
-    region:	""
+    # @section -- Amazon S3 Storage configuration
+    region: ""
     # -- Sets the bucket name for S3 storage
-    bucket:	""
+    # @section -- Amazon S3 Storage configuration
+    bucket: ""
     # -- Sets the key prefix for a S3 object
+    # @section -- Amazon S3 Storage configuration
     keyPrefix: ""
   gcs:
     # -- Contents of Google Application Credentials JSON file (ignored if appCredentialsJsonExistingSecret is set). Optional - if not provided, credentials will be taken from the environment. User credentials if run locally and Google Metadata server if run on a Google Compute Engine. File can be generated for a service account following this guide: https://developers.google.com/workspace/guides/create-credentials#service-account


### PR DESCRIPTION
Hi,

This PR extends the Open WebUI Helm chart to allow the Storage Key to be defined either directly in the values.yaml file or via a Kubernetes Secret. I took the opportunity to define new README.md sections called  "Azure Storage configuration", "Google Cloud Storage configuration", and "Amazon S3 Storage configuration" respectively.

The changes were tested locally using helm template, and the rendering works as expected.

Given a k8s secret like,

```console
kubectl create secret generic azure-storage-account --from-literal=azure-account-key=REDACTED
```

And a values-test.yaml file,

```yaml
# Disable bundled dependencies
ollama:
  enabled: false

pipelines:
  # -- Automatically install Pipelines chart to extend Open WebUI functionality using Pipelines: https://github.com/open-webui/pipelines
  enabled: false
  # -- This section can be used to pass required environment variables to your pipelines (e.g. Langfuse hostname)
  extraEnvVars: []

tika:
  # -- Automatically install Apache Tika to extend Open WebUI
  enabled: false

# -- A list of Ollama API endpoints. These can be added in lieu of automatically installing the Ollama Helm chart, or in addition to it.
ollamaUrls: []

# -- Disables taking Ollama Urls from `ollamaUrls`  list
ollamaUrlsFromExtraEnv: false

websocket:
  # -- Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT`
  enabled: true
  # -- Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default)
  manager: redis
  # -- Deploys a redis
  redis:
    # -- Enable redis installation
    enabled: false

# -- Deploys a Redis cluster with subchart 'redis' from bitnami
redis-cluster:
  # -- Enable Redis installation
  enabled: true
  # -- Redis cluster name (recommended to be 'open-webui-redis')
  # - In this case, redis url will be 'redis://open-webui-redis-master:6379/0' or 'redis://[:<password>@]open-webui-redis-master:6379/0'
  fullnameOverride: open-webui-redis
  # -- Redis Authentication
  auth:
    # -- Enable Redis authentication (disabled by default). For your security, we strongly suggest that you switch to 'auth.enabled=true'
    enabled: false
  # -- Replica configuration for the Redis cluster
  replica:
    # -- Number of Redis replica instances
    replicaCount: 3


replicaCount: 2

serviceAccount:
  enable: true

ingress:
  enabled: true
  class: "external"
  # -- Use appropriate annotations for your Ingress controller, e.g., for NGINX:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt
    nginx.ingress.kubernetes.io/affinity: "cookie"
    nginx.ingress.kubernetes.io/session-cookie-expires: "172800"
    nginx.ingress.kubernetes.io/session-cookie-max-age: "172800"
    nginx.ingress.kubernetes.io/session-cookie-name: "route"
  host: "REDACTED"
  tls: true

persistence:
  enabled: true
  # -- Sets the storage provider, availables values are `local`, `s3`, `gcs` or `azure`
  provider: azure
  azure:
    # -- Sets the endpoint URL for Azure Storage
    endpointUrl: "REDACTED"
    # -- Sets the container name for Azure Storage
    container: "data"
    key: "test"
    keyExistingSecret: "azure-storage-account"
    keyExistingSecretKey: "azure-account-key"

# -- Enables the use of OpenAI APIs
enableOpenaiApi: true

# -- OpenAI base API URL to use. Defaults to the Pipelines service endpoint when Pipelines are enabled, and "https://api.openai.com/v1" if Pipelines are not enabled and this value is blank
openaiBaseApiUrl: "https://api.openai.com/v1"

# -- Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/
extraEnvVars:
  # -- Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines
  # OpenAI config
  - name: OPENAI_API_KEY
    valueFrom:
      secretKeyRef:
        name: openai-api-key
        key: api-key
  - name: ENABLE_MODEL_FILTER
    value: "true"
  - name: MODEL_FILTER_LIST
    value: "gpt-4o-mini;gpt-4o-2024-08-06;ask_hr_policies"
  - name: DEFAULT_MODELS
    value: "gpt-4o-mini"
  - name: DEFAULT_LOCALE
    value: "en_US"
  - name: DEFAULT_USER_ROLE
    value: "user"
  # Blob storage key
  - name: AZURE_STORAGE_KEY
    valueFrom:
      secretKeyRef:
        name: azure-storage-account
        key: azure-account-key
  # Database URL
  - name: DATABASE_URL
    valueFrom:
      secretKeyRef:
        name: postgres-db-url
        key: postgres-url
  # Redis
  - name: WEBSOCKET_REDIS_URL
    value: "redis://infra-openwebui-redis.infra-openwebui.svc.cluster.local:26379/0"
  - name: WEBSOCKET_REDIS_MASTER_NAME
    value: "mymaster"
  - name: WEBSOCKET_REDIS_PASSWORD
    valueFrom:
      secretKeyRef:
        name: redis
        key: secret
  # Log Level
  - name: GLOBAL_LOG_LEVEL
    value: "debug"

sso:
  # -- **Enable SSO authentication globally** must enable to use SSO authentication
  # @section -- SSO Configuration
  enabled: true
  # -- Enable account creation when logging in with OAuth (distinct from regular signup)
  # @section -- SSO Configuration
  enableSignup: false
  # -- Allow logging into accounts that match email from OAuth provider (considered insecure)
  # @section -- SSO Configuration
  mergeAccountsByEmail: false
  # -- Enable OAuth role management through access token roles claim
  # @section -- SSO Configuration
  enableRoleManagement: false
  # -- Enable OAuth group management through access token groups claim
  # @section -- SSO Configuration
  enableGroupManagement: false

  microsoft:
    # -- Enable Microsoft OAuth
    enabled: true
    # -- Microsoft OAuth client ID
    clientId: "REDACTED"
    # -- Microsoft tenant ID - use 9188040d-6c67-4c5b-b112-36a304b66dad for personal accounts
    tenantId: "REDACTED"
    clientSecret: "test"

  roleManagement:
    # -- The claim that contains the roles (can be nested, e.g., user.roles)
    # @section -- Role management configuration
    rolesClaim: "roles"
    # -- Comma-separated list of roles allowed to log in (receive open webui role user)
    # @section -- Role management configuration
    allowedRoles: ""
    # -- Comma-separated list of roles allowed to log in as admin (receive open webui role admin)
    # @section -- Role management configuration
    adminRoles: ""

  groupManagement:
    # -- The claim that contains the groups (can be nested, e.g., user.memberOf)
    # @section -- SSO Configuration
    groupsClaim: "groups"

  trustedHeader:
    # -- Enable trusted header authentication
    # @section -- SSO trusted header authentication
    enabled: false
    # -- Header containing the user's email address
    # @section -- SSO trusted header authentication
    emailHeader: ""
    # -- Header containing the user's name (optional, used for new user creation)
    # @section -- SSO trusted header authentication
    nameHeader: ""

# -- Postgresql configuration (see. https://artifacthub.io/packages/helm/bitnami/postgresql)
postgresql:
  enabled: false
```

With helm template

```console
helm template . --values values-test.yaml > redacted-secret.yaml
```

Now with values-test.yaml changed to,

```yaml
persistence:
  enabled: true
  # -- Sets the storage provider, availables values are `local`, `s3`, `gcs` or `azure`
  provider: azure
  azure:
    # -- Sets the endpoint URL for Azure Storage
    endpointUrl: "REDACTED"
    # -- Sets the container name for Azure Storage
    container: "data"
    key: "test"
    keyExistingSecret: ""
    keyExistingSecretKey: ""
```

The difference is,

```bash
 diff -u redacted-secret.yaml redacted-raw.yaml
--- redacted-secret.yaml        2025-05-06 09:33:30
+++ redacted-raw.yaml   2025-05-06 09:37:04
@@ -499,10 +499,7 @@
         - name: "AZURE_STORAGE_CONTAINER_NAME"
           value: data
         - name: "AZURE_STORAGE_KEY"
-          valueFrom:
-            secretKeyRef:
-              name: azure-storage-account
-              key: azure-account-key
+          value: test
         - name: "ENABLE_WEBSOCKET_SUPPORT"
           value: "True"
         - name: "WEBSOCKET_MANAGER"
```

Thank you!