### PR TITLE
fix(ci): Add milvus repo on `helm-release`

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -65,6 +65,7 @@ jobs:
           helm repo add open-webui https://helm.openwebui.com/
           helm repo add tika https://apache.jfrog.io/artifactory/tika/
           helm repo add redis https://charts.bitnami.com/bitnami
+          helm repo add milvus https://zilliztech.github.io/milvus-helm
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0


### PR DESCRIPTION
Hello! The release for `open-webui-6.5.0` was failed

- This PR fixes the failing pipeline [#14822192905](https://github.com/open-webui/helm-charts/actions/runs/14822192905) triggered by #223
- To resolve the issue, we include the milvus chart in `.github/workflows/helm-release.yml`

Take a look please!