### PR TITLE
feat: Add an example values for RAG and Milvus (triggering open-webui-6.5.0)

### DIFF
--- a/charts/open-webui/values-rag-milvus.yaml
+++ b/charts/open-webui/values-rag-milvus.yaml
@@ -1,0 +1,53 @@
+rag:
+  # -- Enable RAG
+  # ref: https://docs.openwebui.com/getting-started/env-configuration#retrieval-augmented-generation-rag
+  enabled: true
+  vectorDB: milvus
+  embeddingEngine: ""
+  embeddingModel: ""
+
+milvus:
+  # -- Enable Milvus installation. Deploys a Milvus cluster/standalone with subchart 'milvus' from zilliztech
+  # ref: https://github.com/zilliztech/milvus-helm/tree/master/charts/milvus
+  enabled: true
+  uri: "http://open-webui-milvus:19530"
+  db: default
+  token: {}
+  cluster:
+    enabled: false # This means that the Milvus runs with standalone mode
+  minio:
+    enabled: true
+    resources:
+      requests:
+        memory: 50Mi
+    persistence:
+      enabled: true
+      size: 1Gi
+  etcd:
+    enabled: true
+  pulsar:
+    enabled: false
+  pulsarv3:
+    enabled: false
+  kafka:
+    enabled: false
+  externalS3:
+    enabled: false
+  externalEtcd:
+    enabled: false
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+readinessProbe:
+  httpGet:
+    path: /health/db
+    port: http
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 30 # Adjust this value according to the startup time of the application
+  periodSeconds: 10 # Adjust this value according to the startup time of the application
+  failureThreshold: 20 # Adjust this value according to the startup time of the application


### PR DESCRIPTION
To resolve #228,

- This PR will triggered the release pipeline for open-webui-6.5.0
- We include an example values for milvus installation in `charts/open-webui/values-rag-milvus.yaml`
  I checked that I can make the knowledge base with the proposed value
  - commands:
    ```sh
    helm upgrade --install \
    -n owui-milvus --create-namespace \
    -f ./charts/open-webui/values-rag-milvus.yaml \
    open-webui ./charts/open-webui
    ```
  - result screenshot:
    ![image](https://github.com/user-attachments/assets/f0471fff-a59e-48e5-aeb1-6e3a10f41e8c)

I think this PR can complete the release ☺️