### PR TITLE
Update open-webui to v0.6.6 (chart 6.6.0)

### DIFF
--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: ollama
   repository: https://otwld.github.io/ollama-helm/
-  version: 1.14.0
+  version: 1.15.0
 - name: pipelines
   repository: https://helm.openwebui.com
   version: 0.5.0
@@ -10,12 +10,12 @@ dependencies:
   version: 2.9.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 20.12.1
+  version: 20.13.4
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.6.3
+  version: 16.6.6
 - name: milvus
   repository: https://zilliztech.github.io/milvus-helm
-  version: 4.2.45
-digest: sha256:b3b1719be74c19ed412d1dc73f60e0eb5e462e36c59f41cf3a88040c1ed3681d
-generated: "2025-04-17T15:05:19.674229+02:00"
+  version: 4.2.48
+digest: sha256:2b9b6b33588c4c20ec06dc82186d9a3e78cf0f27c5ff0ef2120ecf8eacdd94d3
+generated: "2025-05-06T00:10:31.22+09:00"

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 6.5.0
-appVersion: 0.6.5
+version: 6.6.0
+appVersion: 0.6.6
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.5.0](https://img.shields.io/badge/Version-6.5.0-informational?style=flat-square) ![AppVersion: 0.6.5](https://img.shields.io/badge/AppVersion-0.6.5-informational?style=flat-square)
+![Version: 6.6.0](https://img.shields.io/badge/Version-6.6.0-informational?style=flat-square) ![AppVersion: 0.6.6](https://img.shields.io/badge/AppVersion-0.6.6-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
Hello, guys. It's time to bump the appVersion.

## PR
**chore: Update open-webui to v0.6.6 (chart 6.6.0)**
- update open-webui
    - app: from v0.6.5 to v0.6.6
    - chart: from 6.5.0 to 6.6.0
- updated subchart
    - ollama (from 1.14.0 to 1.15.0): upgrade app version from v0.6.5 to v0.6.6 (see https://github.com/otwld/ollama-helm/compare/ollama-1.14.0...ollama-1.15.0)
    - redis (from 20.12.1 to 20.13.4): app minor update, chart edit (main arguments, sidecar arguments)
    - postgresql (from 16.6.3 to 16.6.6): app minor update, chart edit (backup, update-password)
    - milvus (from 4.2.45 to 4.2.48): upgrade app version from v2.5.9 to v2.5.11 (see https://github.com/zilliztech/milvus-helm/compare/milvus-4.2.45...milvus-4.2.48)