### PR TITLE
feat(open-webui): Add application logging configuration

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 6.9.0
+version: 6.10.0
 appVersion: 0.6.6
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.9.0](https://img.shields.io/badge/Version-6.9.0-informational?style=flat-square) ![AppVersion: 0.6.6](https://img.shields.io/badge/AppVersion-0.6.6-informational?style=flat-square)
+![Version: 6.10.0](https://img.shields.io/badge/Version-6.10.0-informational?style=flat-square) ![AppVersion: 0.6.6](https://img.shields.io/badge/AppVersion-0.6.6-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -40,6 +40,23 @@ helm upgrade --install open-webui open-webui/open-webui
 | https://otwld.github.io/ollama-helm/ | ollama | >=0.24.0 |
 
 ## Values
+
+### Logging configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| logging.components.audio | string | `""` | Set the log level for the Audio processing component |
+| logging.components.comfyui | string | `""` | Set the log level for the ComfyUI Integration component |
+| logging.components.config | string | `""` | Set the log level for the Configuration Management component |
+| logging.components.db | string | `""` | Set the log level for the Database Operations (Peewee) component |
+| logging.components.images | string | `""` | Set the log level for the Image Generation component |
+| logging.components.main | string | `""` | Set the log level for the Main Application Execution component |
+| logging.components.models | string | `""` | Set the log level for the Model Management component |
+| logging.components.ollama | string | `""` | Set the log level for the Ollama Backend Integration component |
+| logging.components.openai | string | `""` | Set the log level for the OpenAI API Integration component |
+| logging.components.rag | string | `""` | Set the log level for the Retrieval-Augmented Generation (RAG) component |
+| logging.components.webhook | string | `""` | Set the log level for the Authentication Webhook component |
+| logging.level | string | `""` | Set the global log level ["notset", "debug", "info" (default), "warning", "error", "critical"] |
 
 ### Azure Storage configuration
 

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -320,6 +320,19 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- if .Values.logging.level }}
+        {{- include "logging.assertValidLevel" .Values.logging.level }}
+        - name: "GLOBAL_LOG_LEVEL"
+          value: {{ .Values.logging.level | quote }}
+        {{- end }}
+
+        {{- if .Values.logging.components }}
+        {{- range $name, $level := .Values.logging.components }}
+        {{- if $level }}
+        {{- include "logging.componentEnvVar" (dict "componentName" $name "logLevel" $level) | indent 8 }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
         {{- if .Values.extraEnvVars }}
           {{- toYaml .Values.extraEnvVars | nindent 8 }}
         {{- end }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -198,6 +198,7 @@ ingress:
   additionalHosts: []
   tls: false
   existingSecret: ""
+
 persistence:
   enabled: true
   size: 2Gi
@@ -544,3 +545,46 @@ postgresql:
       limits:
         memory: 512Mi
         cpu: 500m
+
+# Configure Application logging levels (see. https://docs.openwebui.com/getting-started/advanced-topics/logging#-logging-levels-explained)
+logging:
+  # -- Set the global log level ["notset", "debug", "info" (default), "warning", "error", "critical"]
+  # @section -- Logging configuration
+  level: ""
+
+  # Optional granularity: override log levels per subsystem/component
+  # if not set, it will use the global level (see. https://docs.openwebui.com/getting-started/advanced-topics/logging#%EF%B8%8F-appbackend-specific-logging-levels)
+  components:
+    # -- Set the log level for the Audio processing component
+    # @section -- Logging configuration
+    audio: ""
+    # -- Set the log level for the ComfyUI Integration component
+    # @section -- Logging configuration
+    comfyui: ""
+    # -- Set the log level for the Configuration Management component
+    # @section -- Logging configuration
+    config: ""
+    # -- Set the log level for the Database Operations (Peewee) component
+    # @section -- Logging configuration
+    db: ""
+    # -- Set the log level for the Image Generation component
+    # @section -- Logging configuration
+    images: ""
+    # -- Set the log level for the Main Application Execution component
+    # @section -- Logging configuration
+    main: ""
+    # -- Set the log level for the Model Management component
+    # @section -- Logging configuration
+    models: ""
+    # -- Set the log level for the Ollama Backend Integration component
+    # @section -- Logging configuration
+    ollama: ""
+    # -- Set the log level for the OpenAI API Integration component
+    # @section -- Logging configuration
+    openai: ""
+    # -- Set the log level for the Retrieval-Augmented Generation (RAG) component
+    # @section -- Logging configuration
+    rag: ""
+    # -- Set the log level for the Authentication Webhook component
+    # @section -- Logging configuration
+    webhook: ""


### PR DESCRIPTION
Hi,

This PR add the [Application logging configuration](https://docs.openwebui.com/getting-started/advanced-topics/logging#%EF%B8%8F-application-serverbackend-logging-python) to the Open WebUI Helm chart. 

The changes were tested locally using helm template, and the rendering works as expected.

This is a simple `values.yaml` file for testing,

```yaml
# Disable bundled dependencies
ollama:
  enabled: false

pipelines:
  # -- Automatically install Pipelines chart to extend Open WebUI functionality using Pipelines: https://github.com/open-webui/pipelines
  enabled: false
  # -- This section can be used to pass required environment variables to your pipelines (e.g. Langfuse hostname)
  extraEnvVars: []

tika:
  # -- Automatically install Apache Tika to extend Open WebUI
  enabled: false

# -- A list of Ollama API endpoints. These can be added in lieu of automatically installing the Ollama Helm chart, or in addition to it.
ollamaUrls: []

# -- Disables taking Ollama Urls from `ollamaUrls`  list
ollamaUrlsFromExtraEnv: false

websocket:
  # -- Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT`
  enabled: true
  # -- Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default)
  manager: redis
  # -- Deploys a redis
  redis:
    # -- Enable redis installation
    enabled: false

# -- Deploys a Redis cluster with subchart 'redis' from bitnami
redis-cluster:
  # -- Enable Redis installation
  enabled: true
  # -- Redis cluster name (recommended to be 'open-webui-redis')
  # - In this case, redis url will be 'redis://open-webui-redis-master:6379/0' or 'redis://[:<password>@]open-webui-redis-master:6379/0'
  fullnameOverride: open-webui-redis
  # -- Redis Authentication
  auth:
    # -- Enable Redis authentication (disabled by default). For your security, we strongly suggest that you switch to 'auth.enabled=true'
    enabled: false
  # -- Replica configuration for the Redis cluster
  replica:
    # -- Number of Redis replica instances
    replicaCount: 3


replicaCount: 2

serviceAccount:
  enable: true

ingress:
  enabled: true
  class: "external"
  # -- Use appropriate annotations for your Ingress controller, e.g., for NGINX:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt
    nginx.ingress.kubernetes.io/affinity: "cookie"
  host: "REDACTED"
  tls: true

persistence:
  enabled: true
  # -- Sets the storage provider, availables values are `local`, `s3`, `gcs` or `azure`
  provider: azure
  azure:
    # -- Sets the endpoint URL for Azure Storage
    endpointUrl: "REDACTED"
    # -- Sets the container name for Azure Storage
    container: "data"
    key: "test"
    keyExistingSecret: ""
    keyExistingSecretKey: ""

# -- Enables the use of OpenAI APIs
enableOpenaiApi: true

# -- OpenAI base API URL to use. Defaults to the Pipelines service endpoint when Pipelines are enabled, and "https://api.openai.com/v1" if Pipelines are not enabled and this value is blank
openaiBaseApiUrl: "https://api.openai.com/v1"

# -- Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/
extraEnvVars:
  # -- Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines
  # OpenAI config
  - name: OPENAI_API_KEY
    valueFrom:
      secretKeyRef:
        name: openai-api-key
        key: api-key
  - name: ENABLE_MODEL_FILTER
    value: "true"
  - name: MODEL_FILTER_LIST
    value: "gpt-4o-mini;gpt-4o-2024-08-06;ask_hr_policies"
  - name: DEFAULT_MODELS
    value: "gpt-4o-mini"
  - name: DEFAULT_LOCALE
    value: "en_US"
  - name: DEFAULT_USER_ROLE
    value: "user"
  # Blob storage key
  - name: AZURE_STORAGE_KEY
    valueFrom:
      secretKeyRef:
        name: azure-storage-account
        key: azure-account-key
  # Database URL
  - name: DATABASE_URL
    valueFrom:
      secretKeyRef:
        name: postgres-db-url
        key: postgres-url
  # Redis
  - name: WEBSOCKET_REDIS_URL
    value: "redis://infra-openwebui-redis.infra-openwebui.svc.cluster.local:26379/0"
  - name: WEBSOCKET_REDIS_MASTER_NAME
    value: "mymaster"
  - name: WEBSOCKET_REDIS_PASSWORD
    valueFrom:
      secretKeyRef:
        name: redis
        key: secret
  # Log Level
  - name: GLOBAL_LOG_LEVEL
    value: "debug"

sso:
  # -- **Enable SSO authentication globally** must enable to use SSO authentication
  # @section -- SSO Configuration
  enabled: true
  # -- Enable account creation when logging in with OAuth (distinct from regular signup)
  # @section -- SSO Configuration
  enableSignup: false
  # -- Allow logging into accounts that match email from OAuth provider (considered insecure)
  # @section -- SSO Configuration
  mergeAccountsByEmail: false
  # -- Enable OAuth role management through access token roles claim
  # @section -- SSO Configuration
  enableRoleManagement: false
  # -- Enable OAuth group management through access token groups claim
  # @section -- SSO Configuration
  enableGroupManagement: false

  microsoft:
    # -- Enable Microsoft OAuth
    enabled: true
    # -- Microsoft OAuth client ID
    clientId: "REDACTED"
    # -- Microsoft tenant ID - use 9188040d-6c67-4c5b-b112-36a304b66dad for personal accounts
    tenantId: "REDACTED"
    clientSecret: "test"

  roleManagement:
    # -- The claim that contains the roles (can be nested, e.g., user.roles)
    # @section -- Role management configuration
    rolesClaim: "roles"
    # -- Comma-separated list of roles allowed to log in (receive open webui role user)
    # @section -- Role management configuration
    allowedRoles: ""
    # -- Comma-separated list of roles allowed to log in as admin (receive open webui role admin)
    # @section -- Role management configuration
    adminRoles: ""

  groupManagement:
    # -- The claim that contains the groups (can be nested, e.g., user.memberOf)
    # @section -- SSO Configuration
    groupsClaim: "groups"

  trustedHeader:
    # -- Enable trusted header authentication
    # @section -- SSO trusted header authentication
    enabled: false
    # -- Header containing the user's email address
    # @section -- SSO trusted header authentication
    emailHeader: ""
    # -- Header containing the user's name (optional, used for new user creation)
    # @section -- SSO trusted header authentication
    nameHeader: ""

# -- Postgresql configuration (see. https://artifacthub.io/packages/helm/bitnami/postgresql)
postgresql:
  enabled: false

# Configure Application logging levels (see. https://docs.openwebui.com/getting-started/advanced-topics/logging#-logging-levels-explained)
logging:
  # -- Set the global log level ["notset", "debug", "info" (default), "warning", "error", "critical"]
  # @section -- Logging configuration
  level: "info"

  # Optional granularity: override log levels per subsystem/component
  # if not set, it will use the global level (see. https://docs.openwebui.com/getting-started/advanced-topics/logging#%EF%B8%8F-appbackend-specific-logging-levels)
  components:
    # -- Set the log level for the Audio processing component
    # @section -- Logging configuration
    audio: "error"
    # -- Set the log level for the ComfyUI Integration component
    # @section -- Logging configuration
    comfyui: "warning"
    # -- Set the log level for the Configuration Management component
    # @section -- Logging configuration
    config: "info"
    # -- Set the log level for the Database Operations (Peewee) component
    # @section -- Logging configuration
    db: "error"
    # -- Set the log level for the Image Generation component
    # @section -- Logging configuration
    images: "error"
    # -- Set the log level for the Main Application Execution component
    # @section -- Logging configuration
    main: "error"
    # -- Set the log level for the Model Management component
    # @section -- Logging configuration
    models: "error"
    # -- Set the log level for the Ollama Backend Integration component
    # @section -- Logging configuration
    ollama: "error"
    # -- Set the log level for the OpenAI API Integration component
    # @section -- Logging configuration
    openai: "critical"
    # -- Set the log level for the Retrieval-Augmented Generation (RAG) component
    # @section -- Logging configuration
    rag: "notset"
    # -- Set the log level for the Authentication Webhook component
    # @section -- Logging configuration
    webhook: "error"
```

And then with helm template,

```bash
helm template . --values values.yaml > manifests.yaml
```

**NOTES**:
* See that if you leave the components empty (default), the environment variables will not be added.
* Component names are validated
* Log level values are validated

Thank you!
