### PR TITLE
Add nodeSelector support to websocket Redis deployment

### DIFF
--- a/charts/open-webui/templates/websocket-redis.yaml
+++ b/charts/open-webui/templates/websocket-redis.yaml
@@ -61,6 +61,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.websocket.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -44,6 +44,8 @@ websocket:
   manager: redis
   # -- Specifies the URL of the Redis instance for websocket communication. Template with `redis://[:<password>@]<hostname>:<port>/<db>`
   url: redis://open-webui-redis:6379/0
+  # -- Node selector for websocket pods
+  nodeSelector: {}
   # -- Deploys a redis
   redis:
     # -- Enable redis installation


### PR DESCRIPTION
This PR adds nodeSelector support to the websocket Redis deployment in the Helm chart. It allows users to specify which nodes the Redis pods for websockets should be scheduled on, providing better control over pod placement in Kubernetes clusters.