### PR TITLE
feat(open-webui): support extraLabels for custom metadata in Ingress

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 6.11.0
+version: 6.12.0
 appVersion: 0.6.7
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.11.0](https://img.shields.io/badge/Version-6.11.0-informational?style=flat-square) ![AppVersion: 0.6.7](https://img.shields.io/badge/AppVersion-0.6.7-informational?style=flat-square)
+![Version: 6.12.0](https://img.shields.io/badge/Version-6.12.0-informational?style=flat-square) ![AppVersion: 0.6.7](https://img.shields.io/badge/AppVersion-0.6.7-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -183,7 +183,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | ingress.additionalHosts | list | `[]` |  |
 | ingress.annotations | object | `{}` | Use appropriate annotations for your Ingress controller, e.g., for NGINX: |
 | ingress.class | string | `""` |  |
-| ingress.enabled | bool | `true` |  |
+| ingress.enabled | bool | `false` |  |
 | ingress.existingSecret | string | `""` |  |
 | ingress.extraLabels | object | `{}` | Additional custom labels to add to the Ingress metadata Useful for tagging, selecting, or applying policies to the Ingress via labels. |
 | ingress.host | string | `"chat.example.com"` |  |

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -183,8 +183,9 @@ helm upgrade --install open-webui open-webui/open-webui
 | ingress.additionalHosts | list | `[]` |  |
 | ingress.annotations | object | `{}` | Use appropriate annotations for your Ingress controller, e.g., for NGINX: |
 | ingress.class | string | `""` |  |
-| ingress.enabled | bool | `false` |  |
+| ingress.enabled | bool | `true` |  |
 | ingress.existingSecret | string | `""` |  |
+| ingress.extraLabels | object | `{}` | Additional custom labels to add to the Ingress metadata Useful for tagging, selecting, or applying policies to the Ingress via labels. |
 | ingress.host | string | `"chat.example.com"` |  |
 | ingress.tls | bool | `false` |  |
 | livenessProbe | object | `{}` | Probe for liveness of the Open WebUI container ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes> |

--- a/charts/open-webui/templates/ingress.yaml
+++ b/charts/open-webui/templates/ingress.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ include "open-webui.namespace" . }}
   labels:
     {{- include "open-webui.labels" . | nindent 4 }}
+    {{- with .Values.ingress.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -181,7 +181,7 @@ managedCertificate:
     - chat.example.com # update to your real domain
 
 ingress:
-  enabled: true
+  enabled: false
   class: ""
   # -- Use appropriate annotations for your Ingress controller, e.g., for NGINX:
   annotations: {}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -181,7 +181,7 @@ managedCertificate:
     - chat.example.com # update to your real domain
 
 ingress:
-  enabled: false
+  enabled: true
   class: ""
   # -- Use appropriate annotations for your Ingress controller, e.g., for NGINX:
   annotations: {}
@@ -198,6 +198,12 @@ ingress:
   additionalHosts: []
   tls: false
   existingSecret: ""
+
+  # -- Additional custom labels to add to the Ingress metadata
+  # Useful for tagging, selecting, or applying policies to the Ingress via labels.
+  extraLabels: {}
+  # extraLabels:
+  #   app.kubernetes.io/environment: "staging"
 
 persistence:
   enabled: true


### PR DESCRIPTION
This adds support for `ingress.extraLabels` in the Helm chart, allowing users to define additional metadata labels for the Ingress resource. Includes documentation comments in values.yaml to guide usage.