### PR TITLE
feat(open-webui): add support for commonEnvVars to inject shared environments variables

### DIFF
--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -168,6 +168,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | affinity | object | `{}` | Affinity for pod assignment |
 | annotations | object | `{}` |  |
 | clusterDomain | string | `"cluster.local"` | Value of cluster domain |
+| commonEnvVars | list | `[]` | Env vars added to the Open WebUI deployment, common across environments. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/ (caution: environment variables defined in both `extraEnvVars` and `commonEnvVars` will result in a conflict. Avoid duplicates) |
 | containerSecurityContext | object | `{}` | Configure container security context ref: <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-containe> |
 | copyAppData.resources | object | `{}` |  |
 | databaseUrl | string | `""` | Configure database URL, needed to work with Postgres (example: `postgresql://<user>:<password>@<service>:<port>/<database>`), leave empty to use the default sqlite database |
@@ -240,6 +241,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | volumes | list | `[]` | Configure pod volumes ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/> |
 | websocket.enabled | bool | `false` | Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT` |
 | websocket.manager | string | `"redis"` | Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default) |
+| websocket.nodeSelector | object | `{}` | Node selector for websocket pods |
 | websocket.redis | object | `{"affinity":{},"annotations":{},"args":[],"command":[],"enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"redis","tag":"7.4.2-alpine3.21"},"labels":{},"name":"open-webui-redis","pods":{"annotations":{}},"resources":{},"securityContext":{},"service":{"annotations":{},"containerPort":6379,"labels":{},"nodePort":"","port":6379,"type":"ClusterIP"},"tolerations":[]}` | Deploys a redis |
 | websocket.redis.affinity | object | `{}` | Redis affinity for pod assignment |
 | websocket.redis.annotations | object | `{}` | Redis annotations |

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -336,6 +336,9 @@ spec:
         {{- if .Values.extraEnvVars }}
           {{- toYaml .Values.extraEnvVars | nindent 8 }}
         {{- end }}
+        {{- if .Values.commonEnvVars }}
+          {{- toYaml .Values.commonEnvVars | nindent 8 }}
+        {{- end }}
         {{- if .Values.extraEnvFrom }}
         envFrom:
           {{- toYaml .Values.extraEnvFrom | nindent 8 }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -325,6 +325,11 @@ extraEnvVars:
   # - name: OLLAMA_DEBUG
   #   value: "1"
 
+# -- Env vars added to the Open WebUI deployment, common across environments. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/ (caution: environment variables defined in both `extraEnvVars` and `commonEnvVars` will result in a conflict. Avoid duplicates)
+commonEnvVars: []
+  # - name: RAG_EMBEDDING_ENGINE
+  #   value: "openai"
+
 # -- Env vars added from configmap or secret to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/ (caution: `extraEnvVars` will take precedence over the value from `extraEnvFrom`)
 extraEnvFrom: []
   # - configMapRef:


### PR DESCRIPTION
Allows users to define a list of environment variables that are common across environments, avoiding repetition in `extraEnvVars`.