### PR TITLE
chore: bump chart version to 6.13.0 and update subchart dependencies

### DIFF
--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 1.16.0
 - name: pipelines
   repository: https://helm.openwebui.com
-  version: 0.5.0
+  version: 0.6.0
 - name: tika
   repository: https://apache.jfrog.io/artifactory/tika
   version: 2.9.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 20.13.4
+  version: 21.0.2
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.6.6
-digest: sha256:e997cdfe986786c1a53b8e5dfadb421c85b3c3ba2f8d37196976393667c613f8
-generated: "2025-05-06T08:08:25.994365-06:00"
+  version: 16.7.1
+digest: sha256:f0d1674a2e4f0705c3885b96a48a249daafad6edbc574ac8fd4c16871603761a
+generated: "2025-05-09T14:53:16.625755677+01:00"

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 6.12.0
+version: 6.13.0
 appVersion: 0.6.7
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.12.0](https://img.shields.io/badge/Version-6.12.0-informational?style=flat-square) ![AppVersion: 0.6.7](https://img.shields.io/badge/AppVersion-0.6.7-informational?style=flat-square)
+![Version: 6.13.0](https://img.shields.io/badge/Version-6.13.0-informational?style=flat-square) ![AppVersion: 0.6.7](https://img.shields.io/badge/AppVersion-0.6.7-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
chore: update Chart.lock
- Updated subchart versions (pipelines, redis, postgresql)