### PR TITLE
feat(open-webui): add pod labels to websocket-redis

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 6.13.0
+version: 6.14.0
 appVersion: 0.6.7
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.13.0](https://img.shields.io/badge/Version-6.13.0-informational?style=flat-square) ![AppVersion: 0.6.7](https://img.shields.io/badge/AppVersion-0.6.7-informational?style=flat-square)
+![Version: 6.14.0](https://img.shields.io/badge/Version-6.14.0-informational?style=flat-square) ![AppVersion: 0.6.7](https://img.shields.io/badge/AppVersion-0.6.7-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -243,7 +243,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | websocket.enabled | bool | `false` | Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT` |
 | websocket.manager | string | `"redis"` | Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default) |
 | websocket.nodeSelector | object | `{}` | Node selector for websocket pods |
-| websocket.redis | object | `{"affinity":{},"annotations":{},"args":[],"command":[],"enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"redis","tag":"7.4.2-alpine3.21"},"labels":{},"name":"open-webui-redis","pods":{"annotations":{}},"resources":{},"securityContext":{},"service":{"annotations":{},"containerPort":6379,"labels":{},"nodePort":"","port":6379,"type":"ClusterIP"},"tolerations":[]}` | Deploys a redis |
+| websocket.redis | object | `{"affinity":{},"annotations":{},"args":[],"command":[],"enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"redis","tag":"7.4.2-alpine3.21"},"labels":{},"name":"open-webui-redis","pods":{"annotations":{},"labels":{}},"resources":{},"securityContext":{},"service":{"annotations":{},"containerPort":6379,"labels":{},"nodePort":"","port":6379,"type":"ClusterIP"},"tolerations":[]}` | Deploys a redis |
 | websocket.redis.affinity | object | `{}` | Redis affinity for pod assignment |
 | websocket.redis.annotations | object | `{}` | Redis annotations |
 | websocket.redis.args | list | `[]` | Redis arguments (overrides default) |
@@ -252,8 +252,9 @@ helm upgrade --install open-webui open-webui/open-webui
 | websocket.redis.image | object | `{"pullPolicy":"IfNotPresent","repository":"redis","tag":"7.4.2-alpine3.21"}` | Redis image |
 | websocket.redis.labels | object | `{}` | Redis labels |
 | websocket.redis.name | string | `"open-webui-redis"` | Redis name |
-| websocket.redis.pods | object | `{"annotations":{}}` | Redis pod |
+| websocket.redis.pods | object | `{"annotations":{},"labels":{}}` | Redis pod |
 | websocket.redis.pods.annotations | object | `{}` | Redis pod annotations |
+| websocket.redis.pods.labels | object | `{}` | Redis pod labels |
 | websocket.redis.resources | object | `{}` | Redis resources |
 | websocket.redis.securityContext | object | `{}` | Redis security context |
 | websocket.redis.service | object | `{"annotations":{},"containerPort":6379,"labels":{},"nodePort":"","port":6379,"type":"ClusterIP"}` | Redis service |

--- a/charts/open-webui/templates/websocket-redis.yaml
+++ b/charts/open-webui/templates/websocket-redis.yaml
@@ -21,6 +21,9 @@ spec:
     metadata:
       labels:
         {{- include "websocket.redis.labels" . | nindent 8 }}
+        {{- with .Values.websocket.redis.pods.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- with .Values.websocket.redis.pods.annotations }}
         {{- toYaml . | nindent 8 }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -58,6 +58,8 @@ websocket:
     annotations: {}
     # -- Redis pod
     pods:
+      # -- Redis pod labels
+      labels: {}
       # -- Redis pod annotations
       annotations: {}
     # -- Redis image


### PR DESCRIPTION
Allows users to define labels in the pod-level in websocket redis.