### PR TITLE
chore(open-webui): upgrade open-webui to v0.6.9 (chart v6.15.0)

### DIFF
--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -10,9 +10,9 @@ dependencies:
   version: 2.9.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 21.0.2
+  version: 21.1.3
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.1
-digest: sha256:f0d1674a2e4f0705c3885b96a48a249daafad6edbc574ac8fd4c16871603761a
-generated: "2025-05-09T14:53:16.625755677+01:00"
+  version: 16.7.4
+digest: sha256:7c463e6c0e7f527dc194e3128e96297da3374be04ea925c07b6faa18a843d7a1
+generated: "2025-05-16T20:57:00.282469+02:00"

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 6.14.0
-appVersion: 0.6.7
+version: 6.15.0
+appVersion: 0.6.9
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.14.0](https://img.shields.io/badge/Version-6.14.0-informational?style=flat-square) ![AppVersion: 0.6.7](https://img.shields.io/badge/AppVersion-0.6.7-informational?style=flat-square)
+![Version: 6.15.0](https://img.shields.io/badge/Version-6.15.0-informational?style=flat-square) ![AppVersion: 0.6.9](https://img.shields.io/badge/AppVersion-0.6.9-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
- upgrade open-webui to v0.6.9 (chart v6.15.0)
- upgrade subcharts (redis v21.1.3 - postgresql v16.7.4)