### PR TITLE
chore(open-webui): upgrade open-webui to v0.6.10 (chart v6.16.0)

### DIFF
--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: ollama
   repository: https://otwld.github.io/ollama-helm/
-  version: 1.16.0
+  version: 1.17.0
 - name: pipelines
   repository: https://helm.openwebui.com
   version: 0.6.0
@@ -14,5 +14,5 @@ dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
   version: 16.7.4
-digest: sha256:7c463e6c0e7f527dc194e3128e96297da3374be04ea925c07b6faa18a843d7a1
-generated: "2025-05-16T20:57:00.282469+02:00"
+digest: sha256:2cafa82a52e4b78474a8b505b114bcd5b8da0fa6bdee4bef9969675c43707406
+generated: "2025-05-19T18:58:13.102469+02:00"

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 6.15.0
-appVersion: 0.6.9
+version: 6.16.0
+appVersion: 0.6.10
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.15.0](https://img.shields.io/badge/Version-6.15.0-informational?style=flat-square) ![AppVersion: 0.6.9](https://img.shields.io/badge/AppVersion-0.6.9-informational?style=flat-square)
+![Version: 6.16.0](https://img.shields.io/badge/Version-6.16.0-informational?style=flat-square) ![AppVersion: 0.6.10](https://img.shields.io/badge/AppVersion-0.6.10-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
- upgrade open-webui to [v0.6.10](https://github.com/open-webui/open-webui/releases/tag/v0.6.10) (chart v6.16.0)
- upgrade subcharts (ollama chart [v1.17.0](https://github.com/otwld/ollama-helm/releases/tag/ollama-1.17.0))