### PR TITLE
chore(open-webui): upgrade open-webui to v0.6.11 (chart v6.17.0)

### DIFF
--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -1,18 +1,18 @@
 dependencies:
 - name: ollama
   repository: https://otwld.github.io/ollama-helm/
-  version: 1.17.0
+  version: 1.18.0
 - name: pipelines
   repository: https://helm.openwebui.com
-  version: 0.6.0
+  version: 0.7.0
 - name: tika
   repository: https://apache.jfrog.io/artifactory/tika
   version: 2.9.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 21.1.3
+  version: 21.1.8
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.4
-digest: sha256:2cafa82a52e4b78474a8b505b114bcd5b8da0fa6bdee4bef9969675c43707406
-generated: "2025-05-19T18:58:13.102469+02:00"
+  version: 16.7.5
+digest: sha256:631b70344dbc30bd3ddfc1e95405b9245a1218f7991ffe2905c0a47980c3bfce
+generated: "2025-05-28T02:01:53.857049+02:00"

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 6.16.0
-appVersion: 0.6.10
+version: 6.17.0
+appVersion: 0.6.11
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.16.0](https://img.shields.io/badge/Version-6.16.0-informational?style=flat-square) ![AppVersion: 0.6.10](https://img.shields.io/badge/AppVersion-0.6.10-informational?style=flat-square)
+![Version: 6.17.0](https://img.shields.io/badge/Version-6.17.0-informational?style=flat-square) ![AppVersion: 0.6.11](https://img.shields.io/badge/AppVersion-0.6.11-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
- upgrade open-webui to [v0.6.10](https://github.com/open-webui/open-webui/releases/tag/v0.6.11) (chart v6.17.0)
- upgrade subcharts :
  - ollama chart [v1.18.0](https://github.com/otwld/ollama-helm/releases/tag/ollama-1.18.0)
  - pipelines chart [v0.7.0](https://github.com/open-webui/helm-charts/releases/tag/pipelines-0.7.0)
  - redis chart [v21.1.8](https://github.com/bitnami/charts/blob/main/bitnami/redis/CHANGELOG.md#2118-2025-05-27)
  - postgresql chart [v21.1.8](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/CHANGELOG.md#1675-2025-05-27)