### PR TITLE
fix(open-webui): add WEBUI_URL env var when ingress is enabled

### DIFF
--- a/charts/open-webui/templates/_helpers.tpl
+++ b/charts/open-webui/templates/_helpers.tpl
@@ -233,3 +233,15 @@ Render a logging env var for a component, validating value
 - name: {{ printf "%s_LOG_LEVEL" (upper $name) | quote }}
   value: {{ $level | quote | trim }}
 {{- end }}
+
+{{- /*
+Constructs a string containing the URLs of the Open WebUI based on the ingress configuration
+used to populate the variable WEBUI_URL  
+*/ -}}
+{{- define "openweb-ui.url" -}}
+  {{- $proto := "http" -}}
+  {{- if .Values.ingress.tls -}}
+    {{- $proto = "https" -}}
+  {{- end -}}
+  {{- printf "%s://%s" $proto $.Values.ingress.host }}
+{{- end }}

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -119,6 +119,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         env:
+        {{- if .Values.ingress.enabled }}
+        - name: WEBUI_URL
+          value: {{ include "openweb-ui.url" . }}
+        {{- end }}
         {{- if .Values.ollamaUrlsFromExtraEnv}}
         {{- else if or .Values.ollamaUrls .Values.ollama.enabled }}
         - name: "OLLAMA_BASE_URLS"


### PR DESCRIPTION
When ingress is enabled it adds the WEBUI_URL variable with the value correctly rendered based on the ingress configuration.

This fixes the problem of being redirecting to "http://localhost:3000" once authentication process is completed, when both ingress and sso are enabled.