### PR TITLE
Allow setting WEBUI_URL manually

### DIFF
--- a/charts/open-webui/templates/_helpers.tpl
+++ b/charts/open-webui/templates/_helpers.tpl
@@ -239,9 +239,18 @@ Constructs a string containing the URLs of the Open WebUI based on the ingress c
 used to populate the variable WEBUI_URL  
 */ -}}
 {{- define "openweb-ui.url" -}}
-  {{- $proto := "http" -}}
-  {{- if .Values.ingress.tls -}}
-    {{- $proto = "https" -}}
-  {{- end -}}
-  {{- printf "%s://%s" $proto $.Values.ingress.host }}
+  {{- $url := "" -}}
+  {{- range .Values.extraEnvVars }}
+    {{- if and (eq .name "WEBUI_URL") .value }}
+      {{- $url = .value }}
+    {{- end }}
+  {{- end }}
+  {{- if not $url }}
+    {{- $proto := "http" -}}
+    {{- if .Values.ingress.tls }}
+      {{- $proto = "https" -}}
+    {{- end }}
+    {{- $url = printf "%s://%s" $proto .Values.ingress.host }}
+  {{- end }}
+  {{- $url }}
 {{- end }}

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -119,9 +119,15 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         env:
-        {{- if .Values.ingress.enabled }}
+        {{- $hasCustomWebUIUrl := false }}
+        {{- range .Values.extraEnvVars }}
+          {{- if eq .name "WEBUI_URL" }}
+            {{- $hasCustomWebUIUrl = true }}
+          {{- end }}
+        {{- end }}
+        {{- if and .Values.ingress.enabled (not $hasCustomWebUIUrl) }}
         - name: WEBUI_URL
-          value: {{ include "openweb-ui.url" . }}
+          value: {{ include "openweb-ui.url" . | quote }}
         {{- end }}
         {{- if .Values.ollamaUrlsFromExtraEnv}}
         {{- else if or .Values.ollamaUrls .Values.ollama.enabled }}


### PR DESCRIPTION
We use a redirect in our setup, which means the ingress host is different then the WEBUI_URL. 

This change allows to set the WEBUI_URL either manually via extraenv or via ingress.host