### PR TITLE
Fix issue #253

### DIFF
--- a/charts/open-webui/templates/_helpers.tpl
+++ b/charts/open-webui/templates/_helpers.tpl
@@ -239,18 +239,15 @@ Constructs a string containing the URLs of the Open WebUI based on the ingress c
 used to populate the variable WEBUI_URL  
 */ -}}
 {{- define "openweb-ui.url" -}}
-  {{- $url := "" -}}
-  {{- range .Values.extraEnvVars }}
-    {{- if and (eq .name "WEBUI_URL") .value }}
-      {{- $url = .value }}
-    {{- end }}
-  {{- end }}
-  {{- if not $url }}
+  {{- $webuiEnv := where .Values.extraEnvVars "name" "WEBUI_URL" | first -}}
+  {{- if and $webuiEnv $webuiEnv.value }}
+    {{- $webuiEnv.value }}
+  {{- else }}
     {{- $proto := "http" -}}
     {{- if .Values.ingress.tls }}
       {{- $proto = "https" -}}
     {{- end }}
-    {{- $url = printf "%s://%s" $proto .Values.ingress.host }}
+    {{- printf "%s://%s" $proto .Values.ingress.host }}
   {{- end }}
-  {{- $url }}
 {{- end }}
+


### PR DESCRIPTION
Helm chart 6.20.0 breaks the WEBUI_URL environment variable.

I suspect this is due to reassigning $url multiple times after setting it to null.

Proposed fix.