### PR TITLE
chore(open-webui): upgrade open-webui to v0.6.15 (chart v6.21.0)

### DIFF
--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -10,9 +10,9 @@ dependencies:
   version: 2.9.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 21.2.2
+  version: 21.2.4
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.10
-digest: sha256:a2811c3c3dc518f15595a8606234845852d3cf90b9773f9b4919284c9c474a46
-generated: "2025-06-11T02:00:03.491733+02:00"
+  version: 16.7.12
+digest: sha256:c321c315a3d0be92cb0de7e676564b3f1f550a0ab58436149dfb02e6afb6d2f1
+generated: "2025-06-17T10:58:01.903769+02:00"

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 6.20.0
-appVersion: 0.6.14
+version: 6.21.0
+appVersion: 0.6.15
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.20.0](https://img.shields.io/badge/Version-6.20.0-informational?style=flat-square) ![AppVersion: 0.6.14](https://img.shields.io/badge/AppVersion-0.6.14-informational?style=flat-square)
+![Version: 6.21.0](https://img.shields.io/badge/Version-6.21.0-informational?style=flat-square) ![AppVersion: 0.6.15](https://img.shields.io/badge/AppVersion-0.6.15-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
- upgrade open-webui to [v0.6.15](https://github.com/open-webui/open-webui/releases/tag/v0.6.15) (chart v6.21.0)
- upgrade subcharts :
  - redis [v21.2.4](https://github.com/bitnami/charts/blob/main/bitnami/redis/CHANGELOG.md#2124-2025-06-16)
  - postgresql [v16.7.12](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/CHANGELOG.md#16712-2025-06-16)