### PR TITLE
Support for setting both s3 keys from existing secret

### DIFF
--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -180,7 +180,14 @@ spec:
         - name: "STORAGE_PROVIDER"
           value: {{ .Values.persistence.provider }}
         - name: "S3_ACCESS_KEY_ID"
-          value: {{ .Values.persistence.s3.accessKey }}
+          { { - if .Values.persistence.s3.accessKeyExistingSecret } }
+          valueFrom:
+            secretKeyRef:
+              name: { { .Values.persistence.s3.accessKeyExistingSecret } }
+              key: { { .Values.persistence.s3.accessKeyExistingAccessKey } }
+          { { - else } }
+          value: { { .Values.persistence.s3.accessKey } }
+          { { - end } }
         - name: "S3_SECRET_ACCESS_KEY"
         {{- if .Values.persistence.s3.secretKeyExistingSecret }}
           valueFrom:

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -243,8 +243,14 @@ persistence:
     secretKey: ""
     # -- Set the secret access key for S3 storage from existing k8s secret
     # @section -- Amazon S3 Storage configuration
-    secretKeyExistingSecret: ""
+    accessKeyExistingSecret: ""
     # -- Set the secret access key for S3 storage from existing k8s secret key
+    # @section -- Amazon S3 Storage configuration
+    accessKeyExistingAccessKey: ""
+    # -- Set the secret key for S3 storage from existing k8s secret
+    # @section -- Amazon S3 Storage configuration
+    secretKeyExistingSecret: ""
+    # -- Set the secret key for S3 storage from existing k8s secret key
     # @section -- Amazon S3 Storage configuration
     secretKeyExistingSecretKey: ""
     # -- Sets the endpoint url for S3 storage


### PR DESCRIPTION
If you are using CEPH S3 storage in Kubernetes you get a secret with both accessKey and secretKey. So being able to reuse that secret for setting S3 storage, will make things easier.