### PR TITLE
chore(open-webui): upgrade open-webui to v0.6.18 (chart v6.26.0)

### DIFF
--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: ollama
   repository: https://otwld.github.io/ollama-helm/
-  version: 1.19.0
+  version: 1.24.0
 - name: pipelines
   repository: https://helm.openwebui.com
   version: 0.7.0
@@ -10,9 +10,9 @@ dependencies:
   version: 2.9.0
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 21.2.4
+  version: 21.2.12
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 16.7.12
-digest: sha256:c321c315a3d0be92cb0de7e676564b3f1f550a0ab58436149dfb02e6afb6d2f1
-generated: "2025-06-17T10:58:01.903769+02:00"
+  version: 16.7.20
+digest: sha256:91c4c4d321c432d08ab4ddb09246ce9a4abafd4ec74a1b8ed53745603362fa61
+generated: "2025-07-20T14:53:06.994808+02:00"

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 6.25.0
-appVersion: 0.6.17
+version: 6.26.0
+appVersion: 0.6.18
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 6.25.0](https://img.shields.io/badge/Version-6.25.0-informational?style=flat-square) ![AppVersion: 0.6.17](https://img.shields.io/badge/AppVersion-0.6.17-informational?style=flat-square)
+![Version: 6.26.0](https://img.shields.io/badge/Version-6.26.0-informational?style=flat-square) ![AppVersion: 0.6.18](https://img.shields.io/badge/AppVersion-0.6.18-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
- upgrade open-webui to [v0.6.18](https://github.com/open-webui/open-webui/releases/tag/v0.6.18) (chart v6.26.0)
- upgrade subcharts :
  - ollama [v1.24.0](https://github.com/otwld/ollama-helm/releases/tag/ollama-1.24.0)
  - redis [v21.2.12](https://github.com/bitnami/charts/blob/main/bitnami/redis/CHANGELOG.md#21212-2025-07-16)
  - postgresql [v16.7.20](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/CHANGELOG.md#16720-2025-07-18)

---
*This PR should be merged after #264*