### PR TITLE
Add databaseUrl back again

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 7.0.0
+version: 7.0.1
 appVersion: 0.6.18
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -174,6 +174,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | copyAppData.args | list | `[]` | Open WebUI copy-app-data init container arguments (overrides default) |
 | copyAppData.command | list | `[]` | Open WebUI copy-app-data init container command (overrides default) |
 | copyAppData.resources | object | `{}` |  |
+| databaseUrl | string | `""` | Configure database URL, needed to work with Postgres (example: `postgresql://<user>:<password>@<service>:<port>/<database>`), leave empty to use the default sqlite database |
 | enableOpenaiApi | bool | `true` | Enables the use of OpenAI APIs |
 | extraEnvFrom | list | `[]` | Env vars added from configmap or secret to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/ (caution: `extraEnvVars` will take precedence over the value from `extraEnvFrom`) |
 | extraEnvVars | list | `[{"name":"OPENAI_API_KEY","value":"0p3n-w3bu!"}]` | Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/ |

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 7.0.0](https://img.shields.io/badge/Version-7.0.0-informational?style=flat-square) ![AppVersion: 0.6.18](https://img.shields.io/badge/AppVersion-0.6.18-informational?style=flat-square)
+![Version: 7.0.1](https://img.shields.io/badge/Version-7.0.1-informational?style=flat-square) ![AppVersion: 0.6.18](https://img.shields.io/badge/AppVersion-0.6.18-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -250,9 +250,9 @@ spec:
         - name: "WEBSOCKET_REDIS_URL"
           value: {{ .Values.websocket.url | quote }}
         {{- end }}
-        {{- if or .Values.postgresql.enabled .Values.databaseUrl }}
+        {{- if .Values.databaseUrl }}
         - name: "DATABASE_URL"
-          value: {{ .Values.databaseUrl | default (printf "postgresql://%s:%s@%s:%s/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password .Values.postgresql.fullnameOverride "5432" .Values.postgresql.auth.database) }}
+          value: {{ .Values.databaseUrl | quote }}
         {{- end }}
         {{- if .Values.sso.enabled }}
         {{- if .Values.sso.enableSignup }}

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -250,6 +250,10 @@ spec:
         - name: "WEBSOCKET_REDIS_URL"
           value: {{ .Values.websocket.url | quote }}
         {{- end }}
+        {{- if or .Values.postgresql.enabled .Values.databaseUrl }}
+        - name: "DATABASE_URL"
+          value: {{ .Values.databaseUrl | default (printf "postgresql://%s:%s@%s:%s/%s" .Values.postgresql.auth.username .Values.postgresql.auth.password .Values.postgresql.fullnameOverride "5432" .Values.postgresql.auth.database) }}
+        {{- end }}
         {{- if .Values.sso.enabled }}
         {{- if .Values.sso.enableSignup }}
         - name: "ENABLE_OAUTH_SIGNUP"

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -320,6 +320,9 @@ openaiBaseApiUrls:
   # - "https://api.openai.com/v1"
   # - "https://api.company.openai.com/v1"
 
+# -- Configure database URL, needed to work with Postgres (example: `postgresql://<user>:<password>@<service>:<port>/<database>`), leave empty to use the default sqlite database
+databaseUrl: ""
+
 # -- Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/
 extraEnvVars:
   # -- Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines


### PR DESCRIPTION
In Version 7.0.0 `databaseUrl` has been removed, but this value is not part of bitnamis helm chart and should be available for external Postgres support. 