### PR TITLE
chore(open-webui): upgrade open-webui to v0.6.23 (chart v7.4.0)

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 7.3.0
-appVersion: 0.6.22
+version: 7.4.0
+appVersion: 0.6.23
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 7.3.0](https://img.shields.io/badge/Version-7.3.0-informational?style=flat-square) ![AppVersion: 0.6.22](https://img.shields.io/badge/AppVersion-0.6.22-informational?style=flat-square)
+![Version: 7.4.0](https://img.shields.io/badge/Version-7.4.0-informational?style=flat-square) ![AppVersion: 0.6.23](https://img.shields.io/badge/AppVersion-0.6.23-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
- upgrade open-webui to [v0.6.23](https://github.com/open-webui/open-webui/releases/tag/v0.6.23) (chart v7.4.0)

---
I made 2 PR related to the 2 new versions of Open Webui:
- this one (#285) to upgrade Open Webui to `v0.6.23`.
- another one (#286) to upgrade Open Webui to `v0.6.24` (and subcharts as well). This one is already based on the first one to simplify the rebase process.