### PR TITLE
chore(open-webui): upgrade open-webui to v0.6.24 (chart v7.5.0)

### DIFF
--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: ollama
   repository: https://otwld.github.io/ollama-helm/
-  version: 1.26.0
+  version: 1.27.0
 - name: pipelines
   repository: https://helm.openwebui.com
   version: 0.7.0
 - name: tika
   repository: https://apache.jfrog.io/artifactory/tika
-  version: 2.9.0
-digest: sha256:f98bd85dc5f8bcfa5495d25af68d8e83c20143e945161e042a18be38b085ab53
-generated: "2025-08-07T21:44:59.456533-04:00"
+  version: 3.2.2
+digest: sha256:1c6e5d6a38dc8ebb4e15b1945fb222fa57b10e8882d5c79ba430648f3c5af372
+generated: "2025-08-22T15:22:03.150693+02:00"

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 7.4.0
-appVersion: 0.6.23
+version: 7.5.0
+appVersion: 0.6.24
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 7.4.0](https://img.shields.io/badge/Version-7.4.0-informational?style=flat-square) ![AppVersion: 0.6.23](https://img.shields.io/badge/AppVersion-0.6.23-informational?style=flat-square)
+![Version: 7.5.0](https://img.shields.io/badge/Version-7.5.0-informational?style=flat-square) ![AppVersion: 0.6.24](https://img.shields.io/badge/AppVersion-0.6.24-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
- upgrade open-webui to [v0.6.24](https://github.com/open-webui/open-webui/releases/tag/v0.6.24) (chart v7.5.0)
- upgrade subcharts :
  - ollama [v1.27.0](https://github.com/otwld/ollama-helm/releases/tag/ollama-1.27.0)
  - tika [v3.2.2](https://github.com/apache/tika-helm/releases/tag/v3.2.2)

---
*This PR should be merged after #285*