### PR TITLE
feat: add app.kubernetes.io/name labels

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 8.0.0
+version: 8.1.0
 appVersion: 0.6.26
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 8.0.0](https://img.shields.io/badge/Version-8.0.0-informational?style=flat-square) ![AppVersion: 0.6.26](https://img.shields.io/badge/AppVersion-0.6.26-informational?style=flat-square)
+![Version: 8.1.0](https://img.shields.io/badge/Version-8.1.0-informational?style=flat-square) ![AppVersion: 0.6.26](https://img.shields.io/badge/AppVersion-0.6.26-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 

--- a/charts/open-webui/templates/_helpers.tpl
+++ b/charts/open-webui/templates/_helpers.tpl
@@ -86,6 +86,7 @@ helm.sh/chart: {{ include "chart.name" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "open-webui.name" . }}
 {{- end }}
 
 {{/*

--- a/charts/pipelines/Chart.yaml
+++ b/charts/pipelines/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pipelines
-version: 0.7.0
+version: 0.8.0
 appVersion: "alpha"
 
 home: https://github.com/open-webui/pipelines

--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -1,6 +1,6 @@
 # pipelines
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
 
 Pipelines: UI-Agnostic OpenAI API Plugin Framework
 

--- a/charts/pipelines/templates/_helpers.tpl
+++ b/charts/pipelines/templates/_helpers.tpl
@@ -32,6 +32,7 @@ helm.sh/chart: {{ include "chart.name" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "pipelines.name" . }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
This label is suggested by Helm best practices and have general use for eg. monitoring etc, where the standard set of labels help identify the application.

https://helm.sh/docs/chart_best_practices/labels/