### PR TITLE
feat!: allow redis security context on container level

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 7.8.0
+version: 8.0.0
 appVersion: 0.6.26
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 7.7.0
+version: 7.8.0
 appVersion: 0.6.26
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 7.7.0](https://img.shields.io/badge/Version-7.7.0-informational?style=flat-square) ![AppVersion: 0.6.26](https://img.shields.io/badge/AppVersion-0.6.26-informational?style=flat-square)
+![Version: 8.0.0](https://img.shields.io/badge/Version-8.0.0-informational?style=flat-square) ![AppVersion: 0.6.26](https://img.shields.io/badge/AppVersion-0.6.26-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -240,20 +240,21 @@ helm upgrade --install open-webui open-webui/open-webui
 | websocket.enabled | bool | `false` | Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT` |
 | websocket.manager | string | `"redis"` | Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default) |
 | websocket.nodeSelector | object | `{}` | Node selector for websocket pods |
-| websocket.redis | object | `{"affinity":{},"annotations":{},"args":[],"command":[],"enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"redis","tag":"7.4.2-alpine3.21"},"labels":{},"name":"open-webui-redis","pods":{"annotations":{},"labels":{}},"resources":{},"securityContext":{},"service":{"annotations":{},"containerPort":6379,"labels":{},"nodePort":"","port":6379,"portName":"http","type":"ClusterIP"},"tolerations":[]}` | Deploys a redis |
+| websocket.redis | object | `{"affinity":{},"annotations":{},"args":[],"command":[],"containerSecurityContext":{},"enabled":true,"image":{"pullPolicy":"IfNotPresent","repository":"redis","tag":"7.4.2-alpine3.21"},"labels":{},"name":"open-webui-redis","podSecurityContext":{},"pods":{"annotations":{},"labels":{}},"resources":{},"service":{"annotations":{},"containerPort":6379,"labels":{},"nodePort":"","port":6379,"portName":"http","type":"ClusterIP"},"tolerations":[]}` | Deploys a redis |
 | websocket.redis.affinity | object | `{}` | Redis affinity for pod assignment |
 | websocket.redis.annotations | object | `{}` | Redis annotations |
 | websocket.redis.args | list | `[]` | Redis arguments (overrides default) |
 | websocket.redis.command | list | `[]` | Redis command (overrides default) |
+| websocket.redis.containerSecurityContext | object | `{}` | Redis container security context (certain specs are not allowed on a pod level), if readOnlyRootFilesystem is true, an emtpyDir will be mounted on the redis container |
 | websocket.redis.enabled | bool | `true` | Enable redis installation |
 | websocket.redis.image | object | `{"pullPolicy":"IfNotPresent","repository":"redis","tag":"7.4.2-alpine3.21"}` | Redis image |
 | websocket.redis.labels | object | `{}` | Redis labels |
 | websocket.redis.name | string | `"open-webui-redis"` | Redis name |
+| websocket.redis.podSecurityContext | object | `{}` | Redis pod security context |
 | websocket.redis.pods | object | `{"annotations":{},"labels":{}}` | Redis pod |
 | websocket.redis.pods.annotations | object | `{}` | Redis pod annotations |
 | websocket.redis.pods.labels | object | `{}` | Redis pod labels |
 | websocket.redis.resources | object | `{}` | Redis resources |
-| websocket.redis.securityContext | object | `{}` | Redis security context |
 | websocket.redis.service | object | `{"annotations":{},"containerPort":6379,"labels":{},"nodePort":"","port":6379,"portName":"http","type":"ClusterIP"}` | Redis service |
 | websocket.redis.service.annotations | object | `{}` | Redis service annotations |
 | websocket.redis.service.containerPort | int | `6379` | Redis container/target port |

--- a/charts/open-webui/templates/websocket-redis.yaml
+++ b/charts/open-webui/templates/websocket-redis.yaml
@@ -56,6 +56,11 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if and (hasKey .Values.websocket.redis.containerSecurityContext "readOnlyRootFilesystem") .Values.websocket.redis.containerSecurityContext.readOnlyRootFilesystem }}
+        volumeMounts:
+          - name: data
+            mountPath: "/data"
+        {{- end }}
       {{- with .Values.websocket.redis.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -71,6 +76,11 @@ spec:
       {{- with .Values.websocket.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if and (hasKey .Values.websocket.redis.containerSecurityContext "readOnlyRootFilesystem") .Values.websocket.redis.containerSecurityContext.readOnlyRootFilesystem }}
+      volumes:
+        - name: data
+          emptyDir: {}
       {{- end }}
 ---
 apiVersion: v1

--- a/charts/open-webui/templates/websocket-redis.yaml
+++ b/charts/open-webui/templates/websocket-redis.yaml
@@ -52,6 +52,10 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with .Values.websocket.redis.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- with .Values.websocket.redis.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
@@ -60,7 +64,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.websocket.redis.securityContext }}
+      {{- with .Values.websocket.redis.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -39,7 +39,7 @@ ollamaUrlsFromExtraEnv: false
 
 websocket:
   # -- Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT`
-  enabled: true
+  enabled: false
   # -- Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default)
   manager: redis
   # -- Specifies the URL of the Redis instance for websocket communication. Template with `redis://[:<password>@]<hostname>:<port>/<db>`
@@ -95,21 +95,15 @@ websocket:
     # -- Redis affinity for pod assignment
     affinity: {}
 
-    # -- Redis container security context
+    # -- Redis container security context (certain specs are not allowed on a pod level), if readOnlyRootFilesystem is true, an emtpyDir will be mounted on the redis container
     containerSecurityContext:
-      readOnlyRootFilesystem: true
-      runAsNonRoot: true
-      runAsUser: 2000
-      fsGroup: 2000
-      # runAsUser: 999
-      # runAsGroup: 1000
+      {}
+      # readOnlyRootFilesystem: true
+      # runAsNonRoot: true
 
     # -- Redis pod security context
     podSecurityContext:
-      readOnlyRootFilesystem: true
-      runAsNonRoot: true
-      runAsUser: 2000
-      fsGroup: 2000
+      {}
       # runAsUser: 999
       # runAsGroup: 1000
 
@@ -342,8 +336,6 @@ extraEnvVars:
   # -- Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines
   - name: OPENAI_API_KEY
     value: "0p3n-w3bu!"
-  - name: WEBUI_SECRET_KEY
-    value: "test-dummy-secret-key"
   # valueFrom:
   #   secretKeyRef:
   #     name: pipelines-api-key
@@ -413,12 +405,13 @@ podSecurityContext:
 # -- Configure container security context
 # ref: <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-containe>
 containerSecurityContext:
-  runAsUser: 1001
-  runAsGroup: 1001
-  runAsNonRoot: true
-  privileged: false
-  allowPrivilegeEscalation: false
-  readOnlyRootFilesystem: false
+  {}
+  # runAsUser: 1001
+  # runAsGroup: 1001
+  # runAsNonRoot: true
+  # privileged: false
+  # allowPrivilegeEscalation: false
+  # readOnlyRootFilesystem: false
   # capabilities:
   #   drop:
   #     - ALL

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -39,7 +39,7 @@ ollamaUrlsFromExtraEnv: false
 
 websocket:
   # -- Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT`
-  enabled: false
+  enabled: true
   # -- Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default)
   manager: redis
   # -- Specifies the URL of the Redis instance for websocket communication. Template with `redis://[:<password>@]<hostname>:<port>/<db>`
@@ -95,9 +95,21 @@ websocket:
     # -- Redis affinity for pod assignment
     affinity: {}
 
-    # -- Redis security context
-    securityContext:
-      {}
+    # -- Redis container security context
+    containerSecurityContext:
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 2000
+      fsGroup: 2000
+      # runAsUser: 999
+      # runAsGroup: 1000
+
+    # -- Redis pod security context
+    podSecurityContext:
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 2000
+      fsGroup: 2000
       # runAsUser: 999
       # runAsGroup: 1000
 
@@ -330,6 +342,8 @@ extraEnvVars:
   # -- Default API key value for Pipelines. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines
   - name: OPENAI_API_KEY
     value: "0p3n-w3bu!"
+  - name: WEBUI_SECRET_KEY
+    value: "test-dummy-secret-key"
   # valueFrom:
   #   secretKeyRef:
   #     name: pipelines-api-key
@@ -399,13 +413,12 @@ podSecurityContext:
 # -- Configure container security context
 # ref: <https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-containe>
 containerSecurityContext:
-  {}
-  # runAsUser: 1001
-  # runAsGroup: 1001
-  # runAsNonRoot: true
-  # privileged: false
-  # allowPrivilegeEscalation: false
-  # readOnlyRootFilesystem: false
+  runAsUser: 1001
+  runAsGroup: 1001
+  runAsNonRoot: true
+  privileged: false
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
   # capabilities:
   #   drop:
   #     - ALL


### PR DESCRIPTION
securityContext could only be set on pod level, not container level. So a read only root filesystem could not be
set.

In addition, if readOnlyRootFilesystem is set, mount an emptyDir at /data for redis to have write access.