### PR TITLE
chore(open-webui): upgrade open-webui to v0.6.30 (chart v8.6.0)

### DIFF
--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: ollama
   repository: https://otwld.github.io/ollama-helm/
-  version: 1.27.0
+  version: 1.29.0
 - name: pipelines
   repository: https://helm.openwebui.com
-  version: 0.7.0
+  version: 0.9.0
 - name: tika
   repository: https://apache.jfrog.io/artifactory/tika
   version: 3.2.2
-digest: sha256:1c6e5d6a38dc8ebb4e15b1945fb222fa57b10e8882d5c79ba430648f3c5af372
-generated: "2025-08-22T15:22:03.150693+02:00"
+digest: sha256:2d1a22d6f01272c504dfb8ce0a920f7ef721ac93c9e1ff4e97a3e26ee99153c8
+generated: "2025-09-18T00:37:52.213525+02:00"

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 8.4.0
-appVersion: 0.6.28
+version: 8.5.0
+appVersion: 0.6.29
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: open-webui
-version: 8.5.0
-appVersion: 0.6.29
+version: 8.6.0
+appVersion: 0.6.30
 home: https://www.openwebui.com/
 icon: >-
   https://raw.githubusercontent.com/open-webui/open-webui/main/static/favicon.png

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 8.5.0](https://img.shields.io/badge/Version-8.5.0-informational?style=flat-square) ![AppVersion: 0.6.29](https://img.shields.io/badge/AppVersion-0.6.29-informational?style=flat-square)
+![Version: 8.6.0](https://img.shields.io/badge/Version-8.6.0-informational?style=flat-square) ![AppVersion: 0.6.30](https://img.shields.io/badge/AppVersion-0.6.30-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 8.4.0](https://img.shields.io/badge/Version-8.4.0-informational?style=flat-square) ![AppVersion: 0.6.28](https://img.shields.io/badge/AppVersion-0.6.28-informational?style=flat-square)
+![Version: 8.5.0](https://img.shields.io/badge/Version-8.5.0-informational?style=flat-square) ![AppVersion: 0.6.29](https://img.shields.io/badge/AppVersion-0.6.29-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 


### PR DESCRIPTION
- upgrade open-webui to [v0.6.30](https://github.com/open-webui/open-webui/releases/tag/v0.6.30) (chart v8.6.0)
- upgrade subcharts :
  - ollama [v1.29.0](https://github.com/otwld/ollama-helm/releases/tag/ollama-1.29.0)
  - pipelines [v0.9.0](https://github.com/open-webui/helm-charts/releases/tag/pipelines-0.9.0)

---
*This PR should be merged after #298*