### PR TITLE
Support slim image

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 8.8.0
+version: 8.9.0
 appVersion: 0.6.32
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 8.8.0](https://img.shields.io/badge/Version-8.8.0-informational?style=flat-square) ![AppVersion: 0.6.32](https://img.shields.io/badge/AppVersion-0.6.32-informational?style=flat-square)
+![Version: 8.9.0](https://img.shields.io/badge/Version-8.9.0-informational?style=flat-square) ![AppVersion: 0.6.32](https://img.shields.io/badge/AppVersion-0.6.32-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -183,7 +183,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | extraLabels | object | `{}` |  |
 | extraResources | list | `[]` | Extra resources to deploy with Open WebUI |
 | hostAliases | list | `[]` | HostAliases to be added to hosts-file of each container |
-| image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/open-webui/open-webui","tag":""}` | Open WebUI image tags can be found here: https://github.com/open-webui/open-webui |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/open-webui/open-webui","tag":"","useSlim":false}` | Open WebUI image tags can be found here: https://github.com/open-webui/open-webui |
 | imagePullSecrets | list | `[]` | Configure imagePullSecrets to use private registry ref: <https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry> |
 | ingress.additionalHosts | list | `[]` |  |
 | ingress.annotations | object | `{}` | Use appropriate annotations for your Ingress controller, e.g., for NGINX: |

--- a/charts/open-webui/templates/_helpers.tpl
+++ b/charts/open-webui/templates/_helpers.tpl
@@ -261,3 +261,19 @@ used to populate the variable WEBUI_URL
   {{- end }}
   {{- $url }}
 {{- end }}
+
+{{- /*
+Define a docker tag that should use for the deployment
+*/ -}}
+{{- define "open-webui.tag" -}}
+{{- if .Values.image.tag }}
+{{- /* If user provided an explicit image.tag, use it */ -}}
+{{- .Values.image.tag -}}
+{{- else if .Values.useSlimImage }}
+{{- /* If useSlimImage is true and no explicit tag, use Chart.AppVersion-slim */ -}}
+{{- printf "%s-slim" .Chart.AppVersion -}}
+{{- else }}
+{{- /* Fallback to Chart.AppVersion */ -}}
+{{- .Chart.AppVersion -}}
+{{- end }}
+{{- end }}

--- a/charts/open-webui/templates/_helpers.tpl
+++ b/charts/open-webui/templates/_helpers.tpl
@@ -266,11 +266,12 @@ used to populate the variable WEBUI_URL
 Define a docker tag that should use for the deployment
 */ -}}
 {{- define "open-webui.tag" -}}
-{{- if .Values.image.tag }}
+{{- $image := .Values.image }}
+{{- if $image.tag }}
 {{- /* If user provided an explicit image.tag, use it */ -}}
-{{- .Values.image.tag -}}
-{{- else if .Values.useSlimImage }}
-{{- /* If useSlimImage is true and no explicit tag, use Chart.AppVersion-slim */ -}}
+{{- $image.tag -}}
+{{- else if $image.useSlim }}
+{{- /* If useSlim is true and no explicit tag, use Chart.AppVersion-slim */ -}}
 {{- printf "%s-slim" .Chart.AppVersion -}}
 {{- else }}
 {{- /* Fallback to Chart.AppVersion */ -}}

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -56,7 +56,7 @@ spec:
       initContainers:
       - name: copy-app-data
         {{- with .Values.image }}
-        image: {{ .repository }}:{{ .tag | default $.Chart.AppVersion }}
+        image: {{ .repository }}:{{ include "open-webui.tag" $ }}
         imagePullPolicy: {{ .pullPolicy }}
         {{- end }}
         command:
@@ -99,7 +99,7 @@ spec:
       containers:
       - name: {{ .Chart.Name }}
         {{- with .Values.image }}
-        image: {{ .repository }}:{{ .tag | default $.Chart.AppVersion }}
+        image: {{ .repository }}:{{ include "open-webui.tag" $ }}
         imagePullPolicy: {{ .pullPolicy }}
         {{- end }}
         {{- with .Values.command }}
@@ -166,7 +166,7 @@ spec:
         - name: "OPENAI_API_BASE_URLS"
           value: "{{ include "pipelines.serviceEndpoint" . }};{{ .Values.openaiBaseApiUrl }}"
         {{- else if and .Values.enableOpenaiApi .Values.pipelines.enabled (not .Values.openaiBaseApiUrl) (not .Values.openaiBaseApiUrls) }}
-        # If Pipelines is enabled and no OpenAI API values are set, set OPENAI_API_BASE_URL to the Pipelines server endpoint 
+        # If Pipelines is enabled and no OpenAI API values are set, set OPENAI_API_BASE_URL to the Pipelines server endpoint
         - name: "OPENAI_API_BASE_URL"
           value: {{ include "pipelines.serviceEndpoint" . | quote }}
         {{- else if and .Values.enableOpenaiApi .Values.openaiBaseApiUrls .Values.pipelines.enabled }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -123,11 +123,11 @@ priorityClassName: ""
 # -- Strategy for updating the workload manager: deployment or statefulset
 strategy: {}
 # -- Open WebUI image tags can be found here: https://github.com/open-webui/open-webui
-useSlimImage: false
 image:
   repository: ghcr.io/open-webui/open-webui
   tag: ""
   pullPolicy: "IfNotPresent"
+  useSlim: false
 
 # -- Open WebUI container command (overrides default entrypoint)
 command: []

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -123,6 +123,7 @@ priorityClassName: ""
 # -- Strategy for updating the workload manager: deployment or statefulset
 strategy: {}
 # -- Open WebUI image tags can be found here: https://github.com/open-webui/open-webui
+useSlimImage: false
 image:
   repository: ghcr.io/open-webui/open-webui
   tag: ""


### PR DESCRIPTION
Support slim version by allowing use of image.useSlim in the values.yaml

Image tag resolution uses the helper implemented earlier:

- explicit .Values.image.tag if set
- else .Chart.AppVersion-slim when image.useSlim: true
- else .Chart.AppVersion

Related issue: https://github.com/open-webui/helm-charts/issues/291