### PR TITLE
Support referencing DB password in a secret

### DIFF
--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -297,13 +297,13 @@ helm upgrade --install open-webui open-webui/open-webui
 | copyAppData.args | list | `[]` | Open WebUI copy-app-data init container arguments (overrides default) |
 | copyAppData.command | list | `[]` | Open WebUI copy-app-data init container command (overrides default) |
 | copyAppData.resources | object | `{}` | Resource requests and limits for the Open WebUI copy-app-data init container |
-| databaseUrl | string | `""` | Configure database URL, needed to work with Postgres (example: `postgresql://<user>:<password>@<service>:<port>/<database>`), leave empty to use the default sqlite database |
+| database | object | `{}` | Database configuration Leave this block empty (`{}`) to use the default SQLite database. To use an external database (e.g. PostgreSQL), set `type` and the relevant connection details. |
+| databaseUrl | string | `""` | Legacy full database connection URL. This is still supported for backwards compatibility. If set, it overrides all other individual database connection fields. Example: postgresql://<user>:<password>@<service>:<port>/<database> Leave empty to use the default SQLite database. |
 | extraEnvFrom | list | `[]` | Env vars added from configmap or secret to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/ (caution: `extraEnvVars` will take precedence over the value from `extraEnvFrom`) |
 | extraEnvVars | list | `[]` | Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration. Variables can be defined as list or map style. |
 | extraInitContainers | list | `[]` | Additional init containers to add to the deployment/statefulset ref: <https://kubernetes.io/docs/concepts/workloads/pods/init-containers/> |
 | extraLabels | object | `{}` | Additional custom labels to add to the Open WebUI deployment/statefulset metadata |
 | extraResources | list | `[]` | Extra resources to deploy with Open WebUI |
-| fullnameOverride | string | `""` | String to fully override the default application name |
 | hostAliases | list | `[]` | HostAliases to be added to hosts-file of each container |
 | nameOverride | string | `""` | Provide a name in place of the default application name |
 | namespaceOverride | string | `""` | Provide a namespace in place of the default release namespace |

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -253,9 +253,28 @@ spec:
         - name: "WEBSOCKET_REDIS_URL"
           value: {{ .Values.websocket.url | quote }}
         {{- end }}
+        {{- $db := .Values.database | default dict }}
         {{- if .Values.databaseUrl }}
         - name: "DATABASE_URL"
           value: {{ .Values.databaseUrl | quote }}
+        {{- else if $db.type }}
+        - name: "DATABASE_TYPE"
+          value: {{ $db.type | quote }}
+        - name: "DATABASE_USER"
+          value: {{ $db.user | quote }}
+        - name: "DATABASE_HOST"
+          value: {{ default "5432" $db.port | quote }}
+        - name: "DATABASE_NAME"
+          value: {{ $db.dbName | quote }}
+        - name: "DATABASE_PASSWORD"
+        {{- if $db.passwordSecret }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ $db.passwordSecret }}
+              key: {{ default "password" $db.passwordSecretKey | quote }}
+        {{- else }}
+          value: {{ default "" $db.password | quote }}
+        {{- end }}
         {{- end }}
         {{- if .Values.sso.enabled }}
         {{- if .Values.sso.enableSignup }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -453,7 +453,42 @@ openaiApiKeys:
   - "0p3n-w3bu!"
   # - "sk-4389759834759834"
 
-# -- Configure database URL, needed to work with Postgres (example: `postgresql://<user>:<password>@<service>:<port>/<database>`), leave empty to use the default sqlite database
+# -- Database configuration
+# Leave this block empty (`{}`) to use the default SQLite database.
+# To use an external database (e.g. PostgreSQL), set `type` and the relevant connection details.
+database: {}
+  # These parameters are used to construct the DATABASE_URL in the form
+  #   <type>://<user>:<password>@<host>:<port>/<dbName>
+
+  # -- Database type (e.g. sqlite, postgresql, mysql, sqlite+sqlcipher)
+  # type: postgresql
+
+  # -- Database username
+  # user: open-webui
+
+  # -- Database password. You can either:
+  #    1. Set `password` directly, or
+  #    2. Reference a Kubernetes secret via `passwordSecret`.
+  #       The chart will read the key specified in `passwordSecretKey` (default: `password`)
+  #
+  # password: <db password>
+  # passwordSecret: open-webui-db-secret
+  # passwordSecretKey: password
+
+  # -- Database host
+  # host: my-psql-db
+
+  # -- Database port (optional, default: 5432)
+  # port: 5432
+
+  # -- Name of the database to connect to
+  # dbName: open-webui
+
+# -- Legacy full database connection URL.
+# This is still supported for backwards compatibility.
+# If set, it overrides all other individual database connection fields.
+# Example: postgresql://<user>:<password>@<service>:<port>/<database>
+# Leave empty to use the default SQLite database.
 databaseUrl: ""
 
 # -- Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration. Variables can be defined as list or map style.


### PR DESCRIPTION
Allows us to (optionally) pull the external DB password from a secret rather than including it in plaintext in values.yaml