### PR TITLE
fix(open-webui): wrong behavior on openai api keys

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 8.12.2
+version: 8.12.3
 appVersion: 0.6.34
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 8.12.2](https://img.shields.io/badge/Version-8.12.2-informational?style=flat-square) ![AppVersion: 0.6.34](https://img.shields.io/badge/AppVersion-0.6.34-informational?style=flat-square)
+![Version: 8.12.3](https://img.shields.io/badge/Version-8.12.3-informational?style=flat-square) ![AppVersion: 0.6.34](https://img.shields.io/badge/AppVersion-0.6.34-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -44,7 +44,7 @@ helm upgrade --install open-webui open-webui/open-webui
 |-----|------|---------|-------------|
 | enableOpenaiApi | bool | `true` | Enables the use of OpenAI APIs |
 | openaiApiKey | string | `"0p3n-w3bu!"` | OpenAI API key to use. Default API key value for Pipelines if `openaiBaseApiUrl` is blank. Should be updated in a production deployment, or be changed to the required API key if not using Pipelines |
-| openaiApiKeys | list | `["0p3n-w3bu!"]` | List of OpenAI API keys for each OpenAI base API URLs to use. If `pipelines.enabled` is true, the first key will be used for Pipelines. The number of keys must match the number of URLs in `openaiBaseApiUrls` (it needs one more key if `pipelines.enabled`) and respect the same order |
+| openaiApiKeys | list | `[]` | List of OpenAI API keys for each OpenAI base API URLs to use. The number of keys must match the number of URLs in `openaiBaseApiUrls` and respect the same order. If `pipelines.enabled` is true, it needs one more key (so the list length should be openaiBaseApiUrls length + 1) and the first key will be used for Pipelines. |
 | openaiBaseApiUrl | string | `"https://api.openai.com/v1"` | OpenAI base API URL to use. Defaults to the Pipelines service endpoint when Pipelines are enabled, and "https://api.openai.com/v1" if Pipelines are not enabled and this value is blank |
 | openaiBaseApiUrls | list | `[]` | OpenAI base API URLs to use. Overwrites the value in openaiBaseApiUrl if set |
 

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -155,26 +155,34 @@ spec:
         # If only an OpenAI API value is set, set it to OPENAI_API_BASE_URL
         - name: "OPENAI_API_BASE_URL"
           value: {{ .Values.openaiBaseApiUrl | quote }}
+        {{- if .Values.openaiApiKey }}
         - name: "OPENAI_API_KEY"
           value: {{ .Values.openaiApiKey | quote }}
+        {{- end }}
         {{- else if and .Values.enableOpenaiApi .Values.openaiBaseApiUrl .Values.pipelines.enabled (not .Values.openaiBaseApiUrls) }}
         # If Pipelines is enabled and OpenAI API value is set, use OPENAI_API_BASE_URLS with combined values
         - name: "OPENAI_API_BASE_URLS"
           value: "{{ include "pipelines.serviceEndpoint" . }};{{ .Values.openaiBaseApiUrl }}"
+        {{- if .Values.openaiApiKeys }}
         - name: "OPENAI_API_KEYS"
           value: {{ .Values.openaiApiKeys | join ";" | quote }}
+        {{- end }}
         {{- else if and .Values.enableOpenaiApi .Values.pipelines.enabled (not .Values.openaiBaseApiUrl) (not .Values.openaiBaseApiUrls) }}
         # If Pipelines is enabled and no OpenAI API values are set, set OPENAI_API_BASE_URL to the Pipelines server endpoint
         - name: "OPENAI_API_BASE_URL"
           value: {{ include "pipelines.serviceEndpoint" . | quote }}
+        {{- if .Values.openaiApiKey }}
         - name: "OPENAI_API_KEY"
           value: {{ .Values.openaiApiKey | quote }}
+        {{- end }}
         {{- else if and .Values.enableOpenaiApi .Values.openaiBaseApiUrls .Values.pipelines.enabled }}
         # If OpenAI API value(s) set and Pipelines is enabled, use OPENAI_API_BASE_URLS to support all the endpoints in the chart
         - name: "OPENAI_API_BASE_URLS"
           value: "{{ include "pipelines.serviceEndpoint" . }};{{ join ";" .Values.openaiBaseApiUrls }}"
+        {{- if .Values.openaiApiKeys }}
         - name: "OPENAI_API_KEYS"
           value: {{ .Values.openaiApiKeys | join ";" | quote }}
+        {{- end }}
         {{- else if not .Values.enableOpenaiApi }}
         - name: "ENABLE_OPENAI_API"
           value: "False"

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -450,10 +450,10 @@ openaiBaseApiUrls: []
 # @section -- OpenAI API configuration
 openaiApiKey: "0p3n-w3bu!"
 
-# -- List of OpenAI API keys for each OpenAI base API URLs to use. If `pipelines.enabled` is true, the first key will be used for Pipelines. The number of keys must match the number of URLs in `openaiBaseApiUrls` (it needs one more key if `pipelines.enabled`) and respect the same order
+# -- List of OpenAI API keys for each OpenAI base API URLs to use. The number of keys must match the number of URLs in `openaiBaseApiUrls` and respect the same order. If `pipelines.enabled` is true, it needs one more key (so the list length should be openaiBaseApiUrls length + 1) and the first key will be used for Pipelines.
 # @section -- OpenAI API configuration
-openaiApiKeys:
-  - "0p3n-w3bu!"
+openaiApiKeys: []
+  # - "0p3n-w3bu!"
   # - "sk-4389759834759834"
 
 # -- Configure database URL, needed to work with Postgres (example: `postgresql://<user>:<password>@<service>:<port>/<database>`),


### PR DESCRIPTION
Fix #310 

This pull request updates the Open WebUI Helm chart to version 8.12.3 and refines the configuration for handling OpenAI API keys and endpoints. The changes clarify and improve how multiple OpenAI API keys are provided and used, especially in deployments with Pipelines enabled, and ensure that environment variables are only set when relevant values are present.

**Chart version and documentation updates:**

* Bumped chart version from `8.12.2` to `8.12.3` in `Chart.yaml` and updated the version badge in `README.md` to reflect the new release. [[1]](diffhunk://#diff-fd1c91305ae5ec8685061c0996edf27e8fdf180534d5c02219ed03418765f624L3-R3) [[2]](diffhunk://#diff-f923dfcf40b056769f08b1c67dd4b43fde108d4ddbea3c27e725070d28e9003dL3-R3)

**OpenAI API keys configuration improvements:**

* Changed the default value of `openaiApiKeys` in `values.yaml` from a preset list to an empty list, and updated documentation to clarify how keys should be provided, especially when Pipelines are enabled (the list should match the number of URLs, plus one if Pipelines are used). [[1]](diffhunk://#diff-bbcc9d78d9f50476a0b1619e8a1e9a2377f05aeae7aed666433186247f00f30dL453-R456) [[2]](diffhunk://#diff-f923dfcf40b056769f08b1c67dd4b43fde108d4ddbea3c27e725070d28e9003dL47-R47)
* Updated the Helm template logic in `workload-manager.yaml` to only set the `OPENAI_API_KEY` and `OPENAI_API_KEYS` environment variables if the corresponding values are provided, preventing unnecessary or empty environment variables from being set.