### PR TITLE
feat(open-webui): add workload.kind configuration option

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 8.19.0
+version: 8.20.0
 appVersion: 0.6.41
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 8.19.0](https://img.shields.io/badge/Version-8.19.0-informational?style=flat-square) ![AppVersion: 0.6.41](https://img.shields.io/badge/AppVersion-0.6.41-informational?style=flat-square)
+![Version: 8.20.0](https://img.shields.io/badge/Version-8.20.0-informational?style=flat-square) ![AppVersion: 0.6.41](https://img.shields.io/badge/AppVersion-0.6.41-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -321,6 +321,7 @@ helm upgrade --install open-webui open-webui/open-webui
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pod assignment |
 | volumeMounts | object | `{"container":[],"initContainer":[]}` | Configure container volume mounts ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/> |
 | volumes | list | `[]` | Configure pod volumes ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/> |
+| workload.kind | string | `""` | Workload kind to use. Options are "Deployment", "StatefulSet". If not set, the chart will determine the kind based on persistence settings. NOTE: When using Deployment with local persistence and replicaCount > 1, ensure persistence.accessModes includes ReadWriteMany (RWX). |
 
 ----------------------------------------------
 

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -1,9 +1,11 @@
+{{- /* Validate workload.kind if set */ -}}
+{{- if and .Values.workload.kind (not (or (eq .Values.workload.kind "Deployment") (eq .Values.workload.kind "StatefulSet"))) -}}
+{{- fail "workload.kind must be \"Deployment\" or \"StatefulSet\" (or empty)" -}}
+{{- end -}}
+{{- /* Determine the actual workload kind */ -}}
+{{- $kind := .Values.workload.kind | default (ternary "StatefulSet" "Deployment" (and .Values.persistence.enabled (eq .Values.persistence.provider "local"))) -}}
 apiVersion: apps/v1
-{{- if and .Values.persistence.enabled (eq .Values.persistence.provider "local") }}
-kind: StatefulSet
-{{- else }}
-kind: Deployment
-{{- end }}
+kind: {{ $kind }}
 metadata:
   name: {{ include "open-webui.name" . }}
   namespace: {{ include "open-webui.namespace" . }}
@@ -16,17 +18,17 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  {{- if or (not .Values.persistence.enabled) (not (eq .Values.persistence.provider "local")) }}
+  {{- if eq $kind "Deployment" }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   {{- end }}
-  {{- if and .Values.persistence.enabled (eq .Values.persistence.provider "local") }}
+  {{- if eq $kind "StatefulSet" }}
   serviceName: {{ include "open-webui.name" . }}
   {{- end }}
   selector:
     matchLabels:
       {{- include "open-webui.selectorLabels" . | nindent 6 }}
   {{- if .Values.strategy }}
-  {{- if and .Values.persistence.enabled (eq .Values.persistence.provider "local") }}
+  {{- if eq $kind "StatefulSet" }}
   updateStrategy:
     {{- toYaml .Values.strategy | nindent 4 }}
   {{- else }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -139,6 +139,14 @@ websocket:
       # runAsUser: 999
       # runAsGroup: 1000
 
+
+workload:
+  # -- Workload kind to use. Options are "Deployment", "StatefulSet".
+  # If not set, the chart will determine the kind based on persistence settings.
+  # NOTE: When using Deployment with local persistence and replicaCount > 1,
+  # ensure persistence.accessModes includes ReadWriteMany (RWX).
+  kind: ""
+
 # -- Value of cluster domain
 clusterDomain: cluster.local
 


### PR DESCRIPTION
# Pull Request: Add `workload.kind` Configuration Option

## Description

This PR adds the ability to explicitly set the Kubernetes workload kind (`Deployment` or `StatefulSet`) via `workload.kind` in `values.yaml`.

### Use Case

Users with:
- **ReadWriteMany storage classes** (e.g., Azure Files, NFS, Longhorn RWX) who want all replicas to share a single PVC
- **External databases** (PostgreSQL via CNPG, etc.) who don't need StatefulSet's stable identities
- **Traditional Deployment-based operations** tooling and workflows

Currently, the chart forces `StatefulSet` when `persistence.enabled=true` and `persistence.provider=local`. This prevents users from using `Deployment` even when their storage and architecture support it.

### Changes

1. **`values.yaml`**: Added `workload.kind` option (default: `""` for backwards compatibility)
2. **`templates/workload-manager.yaml`**: Updated kind logic to check `workload.kind` first, falling back to existing behavior
3. **`Chart.yaml`**: Version bump 8.19.0 → 8.20.0 (MINOR - backwards-compatible feature)
4. **`README.md`**: Auto-generated via `helm-docs`

### Backwards Compatibility

✅ **Fully backwards compatible.** If `workload.kind` is not set (default), the existing logic applies:
- `StatefulSet` when `persistence.enabled=true` AND `persistence.provider=local`
- `Deployment` otherwise

---

## Redacted `values.yaml` Used for Testing

```yaml
# Tested on k3s cluster with Longhorn storage and CNPG PostgreSQL

workload:
  kind: Deployment

replicaCount: 2

persistence:
  enabled: true
  size: 10Gi
  accessModes:
    - ReadWriteMany
  storageClass: longhorn

# External PostgreSQL (CNPG)
databaseUrl: "postgresql://user:REDACTED@main-db-rw.databases:5432/openwebui"

ollama:
  enabled: false

pipelines:
  enabled: false

tika:
  enabled: true

websocket:
  enabled: true
  manager: redis
  url: redis://open-webui-redis:6379/0
  redis:
    enabled: true

ingress:
  enabled: true
  class: nginx
  host: chat.example.com
  tls: true

sso:
  enabled: true
  enableSignup: true
  oidc:
    enabled: true
    clientId: "open-webui"
    clientSecret: "REDACTED"
    providerUrl: "https://auth.example.com/application/o/open-webui/.well-known/openid-configuration"
```

---

## Verification

- [x] `helm template` with default values produces `StatefulSet` (unchanged behavior)
- [x] `helm template --set workload.kind=Deployment` produces `Deployment`
- [x] `helm template --set workload.kind=StatefulSet` produces `StatefulSet`
- [x] `helm template --set persistence.enabled=false` produces `Deployment` (unchanged behavior)
- [x] Deployed to live k3s cluster with 2 replicas, RWX Longhorn storage
- [x] Verified file uploads visible across all pods
- [x] **Migration tested**: Converted existing StatefulSet deployment with RAG documents to Deployment mode—all data preserved and functional post-migration
- [x] Ran `helm-docs` to update README
