### PR TITLE
fix: fixed settings sync across replicas

### DIFF
--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 10.2.0
+version: 10.2.1
 appVersion: 0.7.2
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -260,6 +260,8 @@ spec:
           value: "True"
         - name: "WEBSOCKET_MANAGER"
           value: {{ .Values.websocket.manager | default "redis" | quote }}
+        - name: "REDIS_URL"
+          value: {{ .Values.websocket.url | quote }}
         - name: "WEBSOCKET_REDIS_URL"
           value: {{ .Values.websocket.url | quote }}
         {{- end }}


### PR DESCRIPTION
This pull request fixes an issue where settings are not synchronized across multiple replicas.

There is an existing related issue #218.
The official documentation recommends setting both `WEBSOCKET_REDIS_URL` and `REDIS_URL`. However, `REDIS_URL` is not present in the latest release.
<img width="719" height="511" alt="image" src="https://github.com/user-attachments/assets/3cca3bc6-c8d6-4c88-9a2f-b160402ca4fb" />

I deployed Open WebUI locally with 4 replicas and Redis enabled. When `REDIS_URL` was not set, settings were not synchronized across replicas. After applying this change, the issue was resolved.