### PR TITLE
ollama dependency update 1.42 to 1.46

### DIFF
--- a/charts/open-webui/Chart.lock
+++ b/charts/open-webui/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: ollama
   repository: https://otwld.github.io/ollama-helm/
-  version: 1.42.0
+  version: 1.46.0
 - name: pipelines
   repository: https://helm.openwebui.com
   version: 0.10.1
 - name: tika
   repository: https://apache.jfrog.io/artifactory/tika
   version: 3.2.2
-digest: sha256:e8b644f14b7bd95749995e959d2cc146c31a5d3c22693fb43dada61bde3f5642
-generated: "2026-02-13T20:20:43.50837-07:00"
+digest: sha256:f0cd6e9188512f7e055816f439a96a84a3ca61af45bb507d4a279d1e1c33e70b
+generated: "2026-03-01T12:42:23.399528085-05:00"


### PR DESCRIPTION
The lock file pins an older ollama helm chart version which is not yet compatible with qwen3.5