### PR TITLE
feat: enable templating in extraResources

### DIFF
--- a/charts/open-webui/CHANGELOG.md
+++ b/charts/open-webui/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Open WebUI Helm chart will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v14.10.0]
+
+### Changed
+
+- `extraResources` entries are now rendered through Helm's `tpl`, so you can reference release metadata and values inside them (e.g. `namespace: "{{ .Release.Namespace }}"`) and pass raw-string entries in addition to structured objects. This aligns `extraResources` with the rest of the chart, where user-supplied blocks are already templated. Existing entries that contain literal `{{`/`}}` (e.g. Prometheus alert rules, Grafana dashboards) must now be escaped, for example `{{ "{{" }}`.
+
 ## [v14.9.0]
 
 ### Fixed

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 14.9.0
+version: 14.10.0
 appVersion: 0.9.6
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 14.9.0](https://img.shields.io/badge/Version-14.9.0-informational?style=flat-square) ![AppVersion: 0.9.6](https://img.shields.io/badge/AppVersion-0.9.6-informational?style=flat-square)
+![Version: 14.10.0](https://img.shields.io/badge/Version-14.10.0-informational?style=flat-square) ![AppVersion: 0.9.6](https://img.shields.io/badge/AppVersion-0.9.6-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 

--- a/charts/open-webui/templates/extra-resources.yaml
+++ b/charts/open-webui/templates/extra-resources.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.extraResources }}
 {{- range .Values.extraResources }}
 ---
-{{ toYaml . | nindent 0 }}
+{{- if typeIs "string" . }}
+  {{- tpl . $ }}
+{{- else }}
+  {{- tpl (toYaml .) $ }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/open-webui/values-gke-min.yaml
+++ b/charts/open-webui/values-gke-min.yaml
@@ -266,11 +266,11 @@ containerSecurityContext:
   #   type: "RuntimeDefault"
 
 # -- Extra resources to deploy with Open WebUI
-extraResources:
-  []
+extraResources: []
   # - apiVersion: v1
   #   kind: ConfigMap
   #   metadata:
   #     name: example-configmap
+  #     namespace: "{{ .Release.Namespace }}"
   #   data:
   #     example-key: example-value

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -788,6 +788,7 @@ extraResources: []
   #   kind: ConfigMap
   #   metadata:
   #     name: example-configmap
+  #     namespace: "{{ .Release.Namespace }}"
   #   data:
   #     example-key: example-value
 

--- a/charts/pipelines/CHANGELOG.md
+++ b/charts/pipelines/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Pipelines Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0]
+
+### Changed
+
+- `extraResources` entries are now rendered through Helm's `tpl`, so you can reference release metadata and values inside them (e.g. `namespace: "{{ .Release.Namespace }}"`) and pass raw-string entries in addition to structured objects. Existing entries that contain literal `{{`/`}}` must now be escaped, for example `{{ "{{" }}`.
+
 ## [0.11.0]
 
 ### Added

--- a/charts/pipelines/Chart.yaml
+++ b/charts/pipelines/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pipelines
-version: 0.11.0
+version: 0.12.0
 appVersion: "alpha"
 
 home: https://github.com/open-webui/pipelines

--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -1,6 +1,6 @@
 # pipelines
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
 
 Pipelines: UI-Agnostic OpenAI API Plugin Framework
 

--- a/charts/pipelines/templates/extra-resources.yaml
+++ b/charts/pipelines/templates/extra-resources.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.extraResources }}
 {{- range .Values.extraResources }}
 ---
-{{ toYaml . | nindent 0 }}
+{{- if typeIs "string" . }}
+  {{- tpl . $ }}
+{{- else }}
+  {{- tpl (toYaml .) $ }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pipelines/values.yaml
+++ b/charts/pipelines/values.yaml
@@ -156,11 +156,11 @@ volumes: []
 #   emptyDir: {}
 
 # -- Extra resources to deploy with Open WebUI Pipelines
-extraResources:
-  []
+extraResources: []
   # - apiVersion: v1
   #   kind: ConfigMap
   #   metadata:
   #     name: example-configmap
+  #     namespace: "{{ .Release.Namespace }}"
   #   data:
   #     example-key: example-value


### PR DESCRIPTION
This enables templating for the `extraResources`. The idea is taken from the bitnami charts which use `extraDeploy` [example](https://github.com/bitnami/charts/blob/main/bitnami/postgresql/templates/extra-list.yaml).

Please let me know the desired version bump. If interested I can also add something to the changelog.