### PR TITLE
feat(open-webui): allow websockets without Redis

### DIFF
--- a/charts/open-webui/CHANGELOG.md
+++ b/charts/open-webui/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Open WebUI Helm chart will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v14.9.0]
+
+### Fixed
+
+- Allow enabling websockets without Redis. Previously, setting `websocket.enabled: true` always injected `WEBSOCKET_MANAGER` (defaulting an empty value to `redis`) along with `REDIS_URL` and `WEBSOCKET_REDIS_URL`, even when `websocket.redis.enabled: false`, so the in-memory websocket manager could not be used. Now `WEBSOCKET_MANAGER` is only set when `websocket.manager` is non-empty, and `REDIS_URL`/`WEBSOCKET_REDIS_URL` are only set when `websocket.manager` is `redis`. Set `websocket.manager: ""` (and `websocket.redis.enabled: false`) to run Open WebUI's built-in in-memory manager with no Redis. The default behaviour is unchanged.
+
 ## [v14.8.0]
 
 ### Changed

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 14.8.0
+version: 14.9.0
 appVersion: 0.9.6
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 14.8.0](https://img.shields.io/badge/Version-14.8.0-informational?style=flat-square) ![AppVersion: 0.9.6](https://img.shields.io/badge/AppVersion-0.9.6-informational?style=flat-square)
+![Version: 14.9.0](https://img.shields.io/badge/Version-14.9.0-informational?style=flat-square) ![AppVersion: 0.9.6](https://img.shields.io/badge/AppVersion-0.9.6-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -332,14 +332,14 @@ Please consult the [CHANGELOG](CHANGELOG.md) for important upgrade notes and bre
 | websocket.enabled | bool | `true` | Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT` |
 | websocket.existingSecret | string | `""` | Name of an existing Kubernetes secret containing the Redis URL. When set, takes precedence over `websocket.url` |
 | websocket.existingSecretKey | string | `"redis-url"` | Key within the existing secret that contains the Redis URL |
-| websocket.manager | string | `"redis"` | Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default) |
+| websocket.manager | string | `"redis"` | Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: `redis` (default). Set to an empty string (`""`) to use Open WebUI's built-in in-memory manager instead, in which case no Redis is required and neither `REDIS_URL` nor `WEBSOCKET_REDIS_URL` are set (also set `websocket.redis.enabled` to `false` to skip deploying the bundled Redis). Note: the in-memory manager only works with a single replica. |
 | websocket.nodeSelector | object | `{}` | Node selector for websocket pods |
 | websocket.redis.affinity | object | `{}` | Redis affinity for pod assignment |
 | websocket.redis.annotations | object | `{}` | Redis annotations |
 | websocket.redis.args | list | `[]` | Redis arguments (overrides default) |
 | websocket.redis.command | list | `[]` | Redis command (overrides default) |
 | websocket.redis.containerSecurityContext | object | `{}` | Redis container security context (certain specs are not allowed on a pod level), if readOnlyRootFilesystem is true, an emtpyDir will be mounted on the redis container |
-| websocket.redis.enabled | bool | `true` | Enable redis installation |
+| websocket.redis.enabled | bool | `true` | Enable deployment of the bundled Redis used by the `redis` websocket manager. Set to `false` when using an external Redis or when `websocket.manager` is empty (in-memory manager) |
 | websocket.redis.image.pullPolicy | string | `"IfNotPresent"` | Redis image pull policy |
 | websocket.redis.image.repository | string | `"redis"` | Redis image repository |
 | websocket.redis.image.tag | string | `"7.4.2-alpine3.21"` | Redis image tag |

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -332,7 +332,7 @@ Please consult the [CHANGELOG](CHANGELOG.md) for important upgrade notes and bre
 | websocket.enabled | bool | `true` | Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT` |
 | websocket.existingSecret | string | `""` | Name of an existing Kubernetes secret containing the Redis URL. When set, takes precedence over `websocket.url` |
 | websocket.existingSecretKey | string | `"redis-url"` | Key within the existing secret that contains the Redis URL |
-| websocket.manager | string | `"redis"` | Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: `redis` (default). Set to an empty string (`""`) to use Open WebUI's built-in in-memory manager instead, in which case no Redis is required and neither `REDIS_URL` nor `WEBSOCKET_REDIS_URL` are set (also set `websocket.redis.enabled` to `false` to skip deploying the bundled Redis). Note: the in-memory manager only works with a single replica. |
+| websocket.manager | string | `"redis"` | Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: `redis` (default). Set to an empty string (`""`) to use Open WebUI's built-in in-memory manager, in which case no Redis is required. Set `websocket.redis.enabled` to `false` to skip deploying the bundled Redis. Note: the in-memory manager only works with a single replica, see https://docs.openwebui.com/getting-started/advanced-topics/scaling/#step-2--add-redis for more details. |
 | websocket.nodeSelector | object | `{}` | Node selector for websocket pods |
 | websocket.redis.affinity | object | `{}` | Redis affinity for pod assignment |
 | websocket.redis.annotations | object | `{}` | Redis annotations |

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -301,8 +301,11 @@ spec:
         - name: "ENABLE_WEBSOCKET_SUPPORT"
           value: {{ ternary "True" "False" .Values.websocket.enabled | quote }}
         {{- if .Values.websocket.enabled }}
+        {{- if .Values.websocket.manager }}
         - name: "WEBSOCKET_MANAGER"
-          value: {{ .Values.websocket.manager | default "redis" | quote }}
+          value: {{ .Values.websocket.manager | quote }}
+        {{- end }}
+        {{- if eq .Values.websocket.manager "redis" }}
         - name: "REDIS_URL"
         {{- if .Values.websocket.existingSecret }}
           valueFrom:
@@ -320,6 +323,7 @@ spec:
               key: {{ .Values.websocket.existingSecretKey | default "redis-url" }}
         {{- else }}
           value: {{ include "websocket.redis.url" . | quote }}
+        {{- end }}
         {{- end }}
         {{- end }}
         {{- if .Values.databaseUrl }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -67,7 +67,7 @@ websocket:
   # -- Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT`
   # @section -- Websocket configuration
   enabled: true
-  # -- Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: redis (default)
+  # -- Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: `redis` (default). Set to an empty string (`""`) to use Open WebUI's built-in in-memory manager instead, in which case no Redis is required and neither `REDIS_URL` nor `WEBSOCKET_REDIS_URL` are set (also set `websocket.redis.enabled` to `false` to skip deploying the bundled Redis). Note: the in-memory manager only works with a single replica.
   # @section -- Websocket configuration
   manager: redis
   # -- Override the Redis URL for websocket communication. If empty, automatically generates URL based on release name. Template: `redis://[:<password>@]<hostname>:<port>/<db>`
@@ -83,7 +83,7 @@ websocket:
   # @section -- Websocket configuration
   nodeSelector: {}
   redis:
-    # -- Enable redis installation
+    # -- Enable deployment of the bundled Redis used by the `redis` websocket manager. Set to `false` when using an external Redis or when `websocket.manager` is empty (in-memory manager)
     # @section -- Websocket configuration
     enabled: true
     # -- Redis labels

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -67,7 +67,7 @@ websocket:
   # -- Enables websocket support in Open WebUI with env `ENABLE_WEBSOCKET_SUPPORT`
   # @section -- Websocket configuration
   enabled: true
-  # -- Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: `redis` (default). Set to an empty string (`""`) to use Open WebUI's built-in in-memory manager instead, in which case no Redis is required and neither `REDIS_URL` nor `WEBSOCKET_REDIS_URL` are set (also set `websocket.redis.enabled` to `false` to skip deploying the bundled Redis). Note: the in-memory manager only works with a single replica.
+  # -- Specifies the websocket manager to use with env `WEBSOCKET_MANAGER`: `redis` (default). Set to an empty string (`""`) to use Open WebUI's built-in in-memory manager, in which case no Redis is required. Set `websocket.redis.enabled` to `false` to skip deploying the bundled Redis. Note: the in-memory manager only works with a single replica, see https://docs.openwebui.com/getting-started/advanced-topics/scaling/#step-2--add-redis for more details.
   # @section -- Websocket configuration
   manager: redis
   # -- Override the Redis URL for websocket communication. If empty, automatically generates URL based on release name. Template: `redis://[:<password>@]<hostname>:<port>/<db>`


### PR DESCRIPTION
## What

Make it possible to enable websockets **without Redis**, using Open WebUI's built-in in-memory websocket manager.

## Why

Today, setting `websocket.enabled: true` unconditionally injects:

- `WEBSOCKET_MANAGER` — rendered as `{{ .Values.websocket.manager | default "redis" | quote }}`, so even an explicit empty value (`websocket.manager: ""`) is coerced to `redis`
- `REDIS_URL`
- `WEBSOCKET_REDIS_URL`

This happens even when `websocket.redis.enabled: false`, so those env vars end up pointing at a Redis service that is never deployed. There is no value combination that yields websockets enabled with an unset/empty `WEBSOCKET_MANAGER` and no Redis URLs.

The application itself fully supports this: in `backend/open_webui/socket/main.py` the Redis client manager is only used `if WEBSOCKET_MANAGER == 'redis'`, otherwise an in-memory `AsyncServer` is used. `WEBSOCKET_MANAGER` defaults to `""` and `REDIS_URL` defaults to `""` in `env.py`. So an empty manager + no Redis URLs is the intended single-instance, in-memory mode.

## What changed

In `templates/workload-manager.yaml`, the websocket env block now:

- only renders `WEBSOCKET_MANAGER` when `websocket.manager` is non-empty
- only renders `REDIS_URL` / `WEBSOCKET_REDIS_URL` when `websocket.manager == "redis"`

```yaml
{{- if .Values.websocket.enabled }}
{{- if .Values.websocket.manager }}
- name: "WEBSOCKET_MANAGER"
  value: {{ .Values.websocket.manager | quote }}
{{- end }}
{{- if eq .Values.websocket.manager "redis" }}
- name: "REDIS_URL"
  ...
- name: "WEBSOCKET_REDIS_URL"
  ...
{{- end }}
{{- end }}
```

To run websockets without Redis:

```yaml
websocket:
  enabled: true
  manager: ""        # built-in in-memory manager
  redis:
    enabled: false   # don't deploy the bundled Redis
```

> Note: the in-memory manager only works with a single replica.

## Backwards compatibility

The default values (`websocket.manager: redis`, `websocket.redis.enabled: true`) render **identically** to before. External-Redis setups (`manager: redis`, `redis.enabled: false`, custom `websocket.url`/`existingSecret`) are also unchanged.

## Testing

`helm template` output for the relevant cases:

- **Defaults** → `ENABLE_WEBSOCKET_SUPPORT=True`, `WEBSOCKET_MANAGER=redis`, `REDIS_URL` + `WEBSOCKET_REDIS_URL` set (unchanged)
- **`manager: ""`, `redis.enabled: false`** → only `ENABLE_WEBSOCKET_SUPPORT=True`; no `WEBSOCKET_MANAGER`, no `REDIS_URL`, no `WEBSOCKET_REDIS_URL`, no Redis Deployment/Service
- **External Redis (`manager: redis`, `redis.enabled: false`, `websocket.url` set)** → `WEBSOCKET_MANAGER=redis` + both URLs point at the external instance

`helm lint` passes. Chart version bumped `14.8.0` → `14.9.0`; `values.yaml` docs, `README.md`, and `CHANGELOG.md` updated (`helm-docs`-style README rows updated manually).