### PR TITLE
feat(owui): add extraContainers support for sidecar containers

### DIFF
--- a/charts/open-webui/CHANGELOG.md
+++ b/charts/open-webui/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the Open WebUI Helm chart will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v15.2.0]
+Added abillity to add extra init containers
+
 ## [v15.1.0]
 
 ### Changed

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -377,6 +377,7 @@ Please consult the [CHANGELOG](CHANGELOG.md) for important upgrade notes and bre
 | extraEnvFrom | list | `[]` | Env vars added from configmap or secret to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration/ (caution: `extraEnvVars` will take precedence over the value from `extraEnvFrom`) |
 | extraEnvVars | list | `[]` | Env vars added to the Open WebUI deployment. Most up-to-date environment variables can be found here: https://docs.openwebui.com/getting-started/env-configuration. Variables can be defined as list or map style. |
 | extraInitContainers | list | `[]` | Additional init containers to add to the deployment/statefulset ref: <https://kubernetes.io/docs/concepts/workloads/pods/init-containers/> |
+| extraContainers | list | `[]` | Additional containers to add to the deployment/statefulset ref: <https://kubernetes.io/docs/concepts/workloads/pods/#how-pods-manage-multiple-containers> |
 | extraLabels | object | `{}` | Additional custom labels to add to the Open WebUI deployment/statefulset metadata |
 | extraResources | list | `[]` | Extra resources to deploy with Open WebUI |
 | fullnameOverride | string | `""` | Override the full resource name completely. When set, this takes precedence over nameOverride and the standard naming convention. Leave empty to use the standard naming pattern. See the "Resource Naming" section in the README for details on how resources are named. |

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -478,6 +478,9 @@ spec:
           {{- tpl (toYaml .Values.extraEnvFrom) . | nindent 8 }}
         {{- end }}
         tty: true
+      {{- with .Values.extraContainers }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- tpl (toYaml .) $ | nindent 8 }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -626,6 +626,16 @@ extraInitContainers: []
 #   - name: data
 #     mountPath: /data
 
+# -- Additional sidecar containers to add to the deployment/statefulset, alongside the main Open WebUI container
+# ref: <https://kubernetes.io/docs/concepts/workloads/pods/#how-pods-manage-multiple-containers>
+extraContainers: []
+# - name: custom-sidecar
+#   image: busybox:latest
+#   command: ['sh', '-c', 'while true; do echo sidecar running; sleep 30; done']
+#   volumeMounts:
+#   - name: data
+#     mountPath: /data
+
 # -- Configure pod volumes
 # ref: <https://kubernetes.io/docs/tasks/configure-pod-container/configure-volume-storage/>
 volumes: []


### PR DESCRIPTION
By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](https://github.com/open-webui/open-webui/blob/main/CONTRIBUTOR_LICENSE_AGREEMENT), and I am providing my contributions under its terms.

## What
Adds a new extraContainers value to the open-webui chart, allowing
users to attach additional sidecar containers to the Open WebUI
Deployment/StatefulSet pod.

This mirrors the existing extraInitContainers value/pattern — same
shape, same insertion mechanism — just applied to containers:
instead of initContainers:.

## Why
There's currently no way to add a sidecar to the Open WebUI pod.

## Changes
values.yaml: add extraContainers: [] (with commented example)
templates/workload-manager.yaml: render .Values.extraContainers
into the pod spec's containers list, right after the main
container, using the same nindent 6 append pattern as
extraInitContainers
README.md: update to reflect changes made