### PR TITLE
docs(open-webui): document pipelines.resources

### DIFF
--- a/charts/open-webui/CHANGELOG.md
+++ b/charts/open-webui/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the Open WebUI Helm chart will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v15.2.1]
+
+### Added
+- Documented `pipelines.resources` in `values.yaml`/README — this field is already passed through to the Pipelines subchart but was previously undocumented, so it was easy to miss when right-sizing the Pipelines container.
+
 ## [v15.2.0]
 
 ### Changed

--- a/charts/open-webui/CHANGELOG.md
+++ b/charts/open-webui/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the Open WebUI Helm chart will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v16.3.2]
+
+### Added
+- Documented `pipelines.resources` in `values.yaml`/README — this field is already passed through to the Pipelines subchart but was previously undocumented, so it was easy to miss when right-sizing the Pipelines container.
+
 ## [v16.3.1]
 
 ### Fixed

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 15.2.0
+version: 15.2.1
 appVersion: 0.10.2
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 16.3.1
+version: 16.3.2
 appVersion: 0.11.3
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -177,6 +177,7 @@ Please consult the [CHANGELOG](CHANGELOG.md) for important upgrade notes and bre
 | pipelines.enabled | bool | `true` | Automatically install Pipelines chart to extend Open WebUI functionality using Pipelines: https://github.com/open-webui/pipelines |
 | pipelines.extraEnvVars | list | `[]` | This section can be used to pass required environment variables to your pipelines (e.g. Langfuse hostname) |
 | pipelines.fullnameOverride | string | `""` | Override the Pipelines subchart name. If not set, uses the release name with '-pipelines' suffix for multiple instance support |
+| pipelines.resources | object | `{}` | Resource requests/limits for the Pipelines subchart container. See the [pipelines chart's values.yaml](https://github.com/open-webui/helm-charts/blob/main/charts/pipelines/values.yaml) for the full field. |
 | terminals.enabled | bool | `false` | Enable the terminals subchart (operator + orchestrator) |
 | tika.enabled | bool | `false` | Automatically install Apache Tika to extend Open WebUI |
 

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 16.3.1](https://img.shields.io/badge/Version-16.3.1-informational?style=flat-square) ![AppVersion: 0.11.3](https://img.shields.io/badge/AppVersion-0.11.3-informational?style=flat-square)
+![Version: 16.3.2](https://img.shields.io/badge/Version-16.3.2-informational?style=flat-square) ![AppVersion: 0.11.3](https://img.shields.io/badge/AppVersion-0.11.3-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 
@@ -177,6 +177,7 @@ Please consult the [CHANGELOG](CHANGELOG.md) for important upgrade notes and bre
 | pipelines.enabled | bool | `true` | Automatically install Pipelines chart to extend Open WebUI functionality using Pipelines: https://github.com/open-webui/pipelines |
 | pipelines.extraEnvVars | list | `[]` | This section can be used to pass required environment variables to your pipelines (e.g. Langfuse hostname) |
 | pipelines.fullnameOverride | string | `""` | Override the Pipelines subchart name. If not set, uses the release name with '-pipelines' suffix for multiple instance support |
+| pipelines.resources | object | `{}` | Resource requests/limits for the Pipelines subchart container. See the [pipelines chart's values.yaml](https://github.com/open-webui/helm-charts/blob/main/charts/pipelines/values.yaml) for the full field. |
 | terminals.enabled | bool | `false` | Enable the terminals subchart (operator + orchestrator) |
 | tika.enabled | bool | `false` | Automatically install Apache Tika to extend Open WebUI |
 

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -52,6 +52,9 @@ pipelines:
   # -- This section can be used to pass required environment variables to your pipelines (e.g. Langfuse hostname)
   # @section -- External Tools configuration
   extraEnvVars: []
+  # -- Resource requests/limits for the Pipelines subchart container. See the [pipelines chart's values.yaml](https://github.com/open-webui/helm-charts/blob/main/charts/pipelines/values.yaml) for the full field.
+  # @section -- External Tools configuration
+  resources: {}
 
 tika:
   # -- Automatically install Apache Tika to extend Open WebUI


### PR DESCRIPTION
## Summary
- `pipelines.*` values in the `open-webui` chart are passed straight through to the Pipelines subchart, so `pipelines.resources` already works today — but it wasn't declared in `values.yaml`, so it never showed up in the README's values table.
- Found this while right-sizing a homelab deployment: the Pipelines container was running with no resource requests/limits and there was no documented way to set them short of reading the Pipelines subchart's own `values.yaml` directly.
- Added the field with a helm-docs comment, regenerated the README with `helm-docs v1.14.2`, bumped the chart to `15.2.1` (patch), and added a CHANGELOG entry per CONTRIBUTING.md.

## Test plan
- [x] `helm-docs --chart-search-root=.` regenerates `charts/open-webui/README.md` with only the expected new row
- [x] `values.yaml` diff is additive only (no behavior change — the field was already passed through implicitly)
- [ ] Maintainer confirms chart version bump / CHANGELOG format match expectations