### PR TITLE
fix: allign pvc labels to other resources in the chart

### DIFF
--- a/charts/open-webui/CHANGELOG.md
+++ b/charts/open-webui/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the Open WebUI Helm chart will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v16.3.1]
+
+### Fixed
+- The `PersistentVolumeClaim` created when `persistence.enabled` is `true` now carries the full set of common chart labels (`helm.sh/chart`, `app.kubernetes.io/version`, `app.kubernetes.io/managed-by`, `app.kubernetes.io/name`) instead of only the selector labels, making it consistent with every other resource in the chart.
+
 ## [v16.3.0]
 
 ### Changed

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 16.3.0
+version: 16.3.1
 appVersion: 0.11.3
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 16.3.0](https://img.shields.io/badge/Version-16.3.0-informational?style=flat-square) ![AppVersion: 0.11.3](https://img.shields.io/badge/AppVersion-0.11.3-informational?style=flat-square)
+![Version: 16.3.1](https://img.shields.io/badge/Version-16.3.1-informational?style=flat-square) ![AppVersion: 0.11.3](https://img.shields.io/badge/AppVersion-0.11.3-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 

--- a/charts/open-webui/templates/pvc.yaml
+++ b/charts/open-webui/templates/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "open-webui.fullname" . }}
   namespace: {{ include "open-webui.namespace" . }}
   labels:
-    {{- include "open-webui.selectorLabels" . | nindent 4 }}
+    {{- include "open-webui.labels" . | nindent 4 }}
   {{- with .Values.persistence.labels }}
     {{- tpl (toYaml .) $ | nindent 4 }}
   {{- end }}

--- a/charts/pipelines/CHANGELOG.md
+++ b/charts/pipelines/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Pipelines Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.1]
+
+### Fixed
+
+- The `PersistentVolumeClaim` created when `persistence.enabled` is `true` now carries the full set of common chart labels (`helm.sh/chart`, `app.kubernetes.io/version`, `app.kubernetes.io/managed-by`, `app.kubernetes.io/name`) instead of only the selector labels, making it consistent with every other resource in the chart.
+
 ## [0.12.0]
 
 ### Changed

--- a/charts/pipelines/Chart.yaml
+++ b/charts/pipelines/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pipelines
-version: 0.12.0
+version: 0.12.1
 appVersion: "alpha"
 
 home: https://github.com/open-webui/pipelines

--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -1,6 +1,6 @@
 # pipelines
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
+![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
 
 Pipelines: UI-Agnostic OpenAI API Plugin Framework
 

--- a/charts/pipelines/templates/pvc.yaml
+++ b/charts/pipelines/templates/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ include "pipelines.fullname" . }}
   namespace: {{ include "pipelines.namespace" . }}
   labels:
-    {{- include "pipelines.selectorLabels" . | nindent 4 }}
+    {{- include "pipelines.labels" . | nindent 4 }}
   {{- with .Values.persistence.annotations }}
   annotations:
     {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
I notice that the pvc created by the helm chart when persistence is true, contains a subset of labels compared to the other resources.

With this PR the PVC label are consistent with other resources.