### PR TITLE
Ollama and Open AI environment variables not enabled on "first deploy"

### DIFF
--- a/charts/open-webui/templates/_helpers.tpl
+++ b/charts/open-webui/templates/_helpers.tpl
@@ -46,7 +46,7 @@ Constructs a semicolon-separated string of Ollama API endpoint URLs from the oll
 defined in the values.yaml file
 */}}
 {{- define "ollamaUrls" -}}
-{{- if .Values.ollamaUrls }}
+{{- if and .Values.ollamaUrls .Values.ollamaUrlsFromExtraEnv }}
 {{- join ";" .Values.ollamaUrls | trimSuffix "/" }}
 {{- end }}
 {{- end }}

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -145,8 +145,9 @@ spec:
         - name: WEBUI_URL
           value: {{ include "open-webui.url" . | quote }}
         {{- end }}
-        {{- if .Values.ollamaUrlsFromExtraEnv}}
-        {{- else if or .Values.ollamaUrls .Values.ollama.enabled }}
+        {{- if or .Values.ollamaUrlsFromExtraEnv .Values.ollama.enabled }}
+        - name: "ENABLE_OLLAMA_API"
+          value: "True"
         - name: "OLLAMA_BASE_URLS"
           value: {{ include "ollamaBaseUrls" . | quote }}
         {{- else }}

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -231,6 +231,7 @@ spec:
           value: {{ .Values.openaiApiKeys | join ";" | quote }}
         {{- end }}
         {{- end }}
+        {{- end }}
         {{- else }}
         - name: "ENABLE_OPENAI_API"
           value: "False"

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -154,7 +154,8 @@ spec:
         - name: "ENABLE_OLLAMA_API"
           value: "False"
         {{- end }}
-        {{- if and .Values.enableOpenaiApi .Values.openaiBaseApiUrl (not .Values.openaiBaseApiUrls) (not .Values.pipelines.enabled) }}
+        {{- if .Values.enableOpenaiApi }}
+        {{- if .Values.openaiBaseApiUrl (not .Values.openaiBaseApiUrls) (not .Values.pipelines.enabled) }}
         # If only an OpenAI API value is set, set it to OPENAI_API_BASE_URL
         - name: "OPENAI_API_BASE_URL"
           value: {{ tpl .Values.openaiBaseApiUrl . | quote }}
@@ -169,7 +170,7 @@ spec:
           value: {{ .Values.openaiApiKey | quote }}
         {{- end }}
         {{- end }}
-        {{- else if and .Values.enableOpenaiApi .Values.openaiBaseApiUrl .Values.pipelines.enabled (not .Values.openaiBaseApiUrls) }}
+        {{- else if and .Values.openaiBaseApiUrl .Values.pipelines.enabled (not .Values.openaiBaseApiUrls) }}
         # If Pipelines is enabled and OpenAI API value is set, use OPENAI_API_BASE_URLS with combined values
         - name: "OPENAI_API_BASE_URLS"
           value: "{{ include "pipelines.serviceEndpoint" . }};{{ tpl .Values.openaiBaseApiUrl . }}"
@@ -184,7 +185,7 @@ spec:
           value: {{ .Values.openaiApiKeys | join ";" | quote }}
         {{- end }}
         {{- end }}
-        {{- else if and .Values.enableOpenaiApi .Values.pipelines.enabled (not .Values.openaiBaseApiUrl) (not .Values.openaiBaseApiUrls) }}
+        {{- else if and .Values.pipelines.enabled (not .Values.openaiBaseApiUrl) (not .Values.openaiBaseApiUrls) }}
         # If Pipelines is enabled and no OpenAI API values are set, set OPENAI_API_BASE_URL to the Pipelines server endpoint
         - name: "OPENAI_API_BASE_URL"
           value: {{ include "pipelines.serviceEndpoint" . | quote }}
@@ -199,7 +200,7 @@ spec:
           value: {{ .Values.openaiApiKey | quote }}
         {{- end }}
         {{- end }}
-        {{- else if and .Values.enableOpenaiApi .Values.openaiBaseApiUrls .Values.pipelines.enabled }}
+        {{- else if and .Values.openaiBaseApiUrls .Values.pipelines.enabled }}
         # If OpenAI API value(s) set and Pipelines is enabled, use OPENAI_API_BASE_URLS to support all the endpoints in the chart
         - name: "OPENAI_API_BASE_URLS"
           value: "{{ include "pipelines.serviceEndpoint" . }};{{ join ";" .Values.openaiBaseApiUrls }}"
@@ -214,7 +215,7 @@ spec:
           value: {{ .Values.openaiApiKeys | join ";" | quote }}
         {{- end }}
         {{- end }}
-        {{- else if and .Values.enableOpenaiApi .Values.openaiBaseApiUrls (not .Values.pipelines.enabled) }}
+        {{- else if and .Values.openaiBaseApiUrls (not .Values.pipelines.enabled) }}
         # If OpenAI API value(s) set and Pipelines is disabled, use OPENAI_API_BASE_URLS without Pipelines endpoint
         - name: "OPENAI_API_BASE_URLS"
           value: {{ join ";" .Values.openaiBaseApiUrls | quote }}
@@ -229,7 +230,7 @@ spec:
           value: {{ .Values.openaiApiKeys | join ";" | quote }}
         {{- end }}
         {{- end }}
-        {{- else if not .Values.enableOpenaiApi }}
+        {{- else }}
         - name: "ENABLE_OPENAI_API"
           value: "False"
         {{- end }}

--- a/charts/open-webui/templates/workload-manager.yaml
+++ b/charts/open-webui/templates/workload-manager.yaml
@@ -155,8 +155,9 @@ spec:
           value: "False"
         {{- end }}
         {{- if .Values.enableOpenaiApi }}
-        {{- if .Values.openaiBaseApiUrl (not .Values.openaiBaseApiUrls) (not .Values.pipelines.enabled) }}
-        # If only an OpenAI API value is set, set it to OPENAI_API_BASE_URL
+        - name: "ENABLE_OPENAI_API"
+          value: "True"
+        {{- if and .Values.openaiBaseApiUrl (not .Values.openaiBaseApiUrls) (not .Values.pipelines.enabled) }}
         - name: "OPENAI_API_BASE_URL"
           value: {{ tpl .Values.openaiBaseApiUrl . | quote }}
         {{- if or .Values.openaiApiKey .Values.openaiApiKeyExistingSecret }}

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -33,8 +33,6 @@ ollama:
   # persistentVolume:
   #   enabled: true
   #   volumeName: "example-pre-existing-pv-created-by-smb-csi"
-  service:
-    port: 11434
 
 # -- A list of Ollama API endpoints. These can be added in lieu of automatically installing the Ollama Helm chart, or in addition to it.
 # @section -- External Tools configuration

--- a/charts/open-webui/values.yaml
+++ b/charts/open-webui/values.yaml
@@ -33,6 +33,8 @@ ollama:
   # persistentVolume:
   #   enabled: true
   #   volumeName: "example-pre-existing-pv-created-by-smb-csi"
+  service:
+    port: 11434
 
 # -- A list of Ollama API endpoints. These can be added in lieu of automatically installing the Ollama Helm chart, or in addition to it.
 # @section -- External Tools configuration


### PR DESCRIPTION
The ENABLE_OLLAMA_API and ENABLE_OPENAI_API environment variables were not set even when corresponding pipelines/ollamaUrls were provided. Refactored the conditionals. 