### PR TITLE
fix: avoid trimming YAML document separator in extraResources tpl

### DIFF
--- a/charts/open-webui/CHANGELOG.md
+++ b/charts/open-webui/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to the Open WebUI Helm chart will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v16.3.4]
+
+### Fixed
+- `extraResources` entries are now rendered without trimming the leading newline after the `---` document separator, which caused `helm lint -f values.yaml` to fail with `unable to parse YAML: invalid Yaml document separator` for both structured (YAML object) and raw-string entries. `helm template` was unaffected.
+
 ## [v16.3.3]
 
 ### Added

--- a/charts/open-webui/Chart.yaml
+++ b/charts/open-webui/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: open-webui
-version: 16.3.3
+version: 16.3.4
 appVersion: 0.11.3
 home: https://www.openwebui.com/
 icon: >-

--- a/charts/open-webui/README.md
+++ b/charts/open-webui/README.md
@@ -1,6 +1,6 @@
 # open-webui
 
-![Version: 16.3.2](https://img.shields.io/badge/Version-16.3.2-informational?style=flat-square) ![AppVersion: 0.11.3](https://img.shields.io/badge/AppVersion-0.11.3-informational?style=flat-square)
+![Version: 16.3.4](https://img.shields.io/badge/Version-16.3.4-informational?style=flat-square) ![AppVersion: 0.11.3](https://img.shields.io/badge/AppVersion-0.11.3-informational?style=flat-square)
 
 Open WebUI: A User-Friendly Web Interface for Chat Interactions 👋
 

--- a/charts/open-webui/templates/extra-resources.yaml
+++ b/charts/open-webui/templates/extra-resources.yaml
@@ -2,9 +2,9 @@
 {{- range .Values.extraResources }}
 ---
 {{- if typeIs "string" . }}
-  {{- tpl . $ }}
+{{ tpl . $ }}
 {{- else }}
-  {{- tpl (toYaml .) $ }}
+{{ tpl (toYaml .) $ }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pipelines/CHANGELOG.md
+++ b/charts/pipelines/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Pipelines Helm chart will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.2]
+
+### Fixed
+
+- `extraResources` entries are now rendered without trimming the leading newline after the `---` document separator, which caused `helm lint -f values.yaml` to fail with `unable to parse YAML: invalid Yaml document separator` for both structured (YAML object) and raw-string entries. `helm template` was unaffected.
+
 ## [0.12.1]
 
 ### Fixed

--- a/charts/pipelines/Chart.yaml
+++ b/charts/pipelines/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pipelines
-version: 0.12.1
+version: 0.12.2
 appVersion: "alpha"
 
 home: https://github.com/open-webui/pipelines

--- a/charts/pipelines/README.md
+++ b/charts/pipelines/README.md
@@ -1,6 +1,6 @@
 # pipelines
 
-![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
+![Version: 0.12.2](https://img.shields.io/badge/Version-0.12.2-informational?style=flat-square) ![AppVersion: alpha](https://img.shields.io/badge/AppVersion-alpha-informational?style=flat-square)
 
 Pipelines: UI-Agnostic OpenAI API Plugin Framework
 

--- a/charts/pipelines/templates/extra-resources.yaml
+++ b/charts/pipelines/templates/extra-resources.yaml
@@ -2,9 +2,9 @@
 {{- range .Values.extraResources }}
 ---
 {{- if typeIs "string" . }}
-  {{- tpl . $ }}
+{{ tpl . $ }}
 {{- else }}
-  {{- tpl (toYaml .) $ }}
+{{ tpl (toYaml .) $ }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Closes https://github.com/open-webui/helm-charts/issues/420